### PR TITLE
Honor the existing resources quantity

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -39,6 +39,7 @@ func main() {
 	injectHugepageDownApi := flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
 	flag.Var(&clientCAPaths, "client-ca", "File containing client CA. This flag is repeatable if more than one client CA needs to be added to server")
 	resourceNameKeys := flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
+	resourceHonorFlag := flag.Bool("honor-resource", false, "Honor the existing resources --honor-resource")
 	flag.Parse()
 
 	if *port < 1024 || *port > 65535 {
@@ -69,6 +70,8 @@ func main() {
 	webhook.SetupInClusterClient()
 
 	webhook.SetInjectHugepageDownApi(*injectHugepageDownApi)
+
+	webhook.SetHonorExistingResources(*resourceHonorFlag)
 
 	err = webhook.SetResourceNameKeys(*resourceNameKeys)
 	if err != nil {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -39,7 +39,7 @@ func main() {
 	injectHugepageDownApi := flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
 	flag.Var(&clientCAPaths, "client-ca", "File containing client CA. This flag is repeatable if more than one client CA needs to be added to server")
 	resourceNameKeys := flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
-	resourceHonorFlag := flag.Bool("honor-resource", false, "Honor the existing resources --honor-resource")
+	resourcesHonorFlag := flag.Bool("honor-resources", false, "Honor the existing requested resources requests & limits --honor-resources")
 	flag.Parse()
 
 	if *port < 1024 || *port > 65535 {
@@ -71,7 +71,7 @@ func main() {
 
 	webhook.SetInjectHugepageDownApi(*injectHugepageDownApi)
 
-	webhook.SetHonorExistingResources(*resourceHonorFlag)
+	webhook.SetHonorExistingResources(*resourcesHonorFlag)
 
 	err = webhook.SetResourceNameKeys(*resourceNameKeys)
 	if err != nil {


### PR DESCRIPTION
This commit ensures the quantities specified in the resources
are considered along with nri injecting resource based on the
network name annotation.
This way other applications (example: networkservicemesh) can
also request the device(s) from the same resource pool along
with resource requested for multus secondary network interface.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>