### PR TITLE
Expose hugepage requests to container via Downward API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin
 *.dll
 *.so
 *.dylib
+.gopath/*
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -118,8 +118,14 @@ make vendor
 
 ## Security
 ### Disable adding client CAs to server TLS endpoint
-If you wish to not add any client CAs to the servers TLS endpoint, add ```--insecure``` flag to webhook binary arguments.
+If you wish to not add any client CAs to the servers TLS endpoint, add ```--insecure``` flag to webhook binary arguments (See [server.yaml](deployments/server.yaml)).
 
 ### Client CAs
 By default, we consume the client CA from the Kubernetes service account secrets directory ```/var/run/secrets/kubernetes.io/serviceaccount/```.
 If you wish to consume a client CA from a different location, please specify flag ```--client-ca``` with a valid path. If you wish to add more than one client CA, repeat this flag multiple times. If ```--client-ca``` is defined, the default client CA from the service account secrets directory will not be consumed.
+
+## Other Configuration
+### Expose Hugepages via Downward API
+In Kubernetes 1.20, an alpha feature was added to expose the requested hugepages to the container via the Downward API.
+Being alpha, this feature is disabled in Kubernetes by default.
+If enabled when Kubernetes is deployed via `FEATURE_GATES="DownwardAPIHugePages=true"`, then Network Resource Injector can be used to mutate the pod spec to publish the hugepage data to the container. To enable this functionality in Network Resource Injector, add ```--injectHugepageDownApi``` flag to webhook binary arguments (See [server.yaml](deployments/server.yaml)).

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -36,6 +36,7 @@ func main() {
 	cert := flag.String("tls-cert-file", "cert.pem", "File containing the default x509 Certificate for HTTPS.")
 	key := flag.String("tls-private-key-file", "key.pem", "File containing the default x509 private key matching --tls-cert-file.")
 	insecure := flag.Bool("insecure", false, "Disable adding client CA to server TLS endpoint --insecure")
+	injectHugepageDownApi := flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
 	flag.Var(&clientCAPaths, "client-ca", "File containing client CA. This flag is repeatable if more than one client CA needs to be added to server")
 	resourceNameKeys := flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
 	flag.Parse()
@@ -66,6 +67,8 @@ func main() {
 
 	/* init API client */
 	webhook.SetupInClusterClient()
+
+	webhook.SetInjectHugepageDownApi(*injectHugepageDownApi)
 
 	err = webhook.SetResourceNameKeys(*resourceNameKeys)
 	if err != nil {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	if *address == "" || *cert == "" || *key == "" || *resourceNameKeys == "" {
 		glog.Fatalf("input argument(s) not defined correctly")
-        }
+	}
 
 	if len(clientCAPaths) == 0 {
 		clientCAPaths = append(clientCAPaths, defaultClientCa)
@@ -85,7 +85,7 @@ func main() {
 				http.Error(w, "Invalid HTTP verb requested", 405)
 				return
 			}
-			webhook.MutateHandler(w,r)
+			webhook.MutateHandler(w, r)
 		})
 
 		/* start serving */
@@ -102,7 +102,7 @@ func main() {
 				ClientCAs:                clientCaPool.GetCertPool(),
 				PreferServerCipherSuites: true,
 				InsecureSkipVerify:       false,
-				CipherSuites: []uint16 {
+				CipherSuites: []uint16{
 					// tls 1.2
 					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cloudflare/cfssl v1.4.1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.1-0.20201119153432-9d213757d22d
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,10 @@ github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jB
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
@@ -51,6 +53,7 @@ github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZ
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.10.0+incompatible h1:l6Soi8WCOOVAeCo4W98iBFC6Og7/X8bpRt51oNLZ2C8=
 github.com/emicklei/go-restful v2.10.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
@@ -63,14 +66,18 @@ github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2H
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
+github.com/go-openapi/jsonpointer v0.19.3 h1:gihV7YNZK1iK6Tgwwsxo2rJbD1GTbdm72325Bq8FI3w=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
+github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/spec v0.0.0-20160808142527-6aced65f8501/go.mod h1:J8+jY1nAiCcj+friV/PDoE1/3eeccG9LYBs0tYvLOWc=
+github.com/go-openapi/spec v0.19.3 h1:0XRyw8kguri6Yw4SxhsQA/atC88yqrk0+G4YhI2wabc=
 github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8Lj9mJglo=
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-sql-driver/mysql v1.3.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -138,8 +145,8 @@ github.com/juju/errors v0.0.0-20180806074554-22422dad46e1/go.mod h1:W54LbzXuIE0b
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20190613124551-e81189438503/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200127152046-0ee521d56061/go.mod h1:MP2HbArq3QT+oVp8pmtHNZnSnkhdkHtDnc7h6nJXmBU=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc h1:M7bj0RX9dc79YIyptmHm0tPmC/WuIbn+HVeTBDK2KZw=
-github.com/k8snetworkplumbingwg/network-attachment-definition-client v0.0.0-20200626054723-37f83d1996bc/go.mod h1:+1DpV8uIwteAhxNO0lgRox8gHkTG6w3OeDfAlg+qqjA=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.1-0.20201119153432-9d213757d22d h1:9QbZltQGRFe7temwcTDjj8rIbow48Gv6mIKOxuks+OI=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.1-0.20201119153432-9d213757d22d/go.mod h1:+1DpV8uIwteAhxNO0lgRox8gHkTG6w3OeDfAlg+qqjA=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kisielk/sqlstruct v0.0.0-20150923205031-648daed35d49/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
@@ -156,6 +163,7 @@ github.com/lib/pq v0.0.0-20180201184707-88edab080323/go.mod h1:5WUZQaWbwv1U+lTRe
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
@@ -312,6 +320,7 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0 h1:7+F62GGWUowoiJOUDivedlBECd/fTeUDJnCu0JetQO0=
 golang.org/x/tools v0.0.0-20190930201159-7c411dea38b0/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -373,10 +382,12 @@ k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCk
 k8s.io/client-go v0.18.5 h1:cLhGZdOmyPhwtt20Lrb7uAqxxB1uvY+NTmNJvno1oKA=
 k8s.io/client-go v0.18.5/go.mod h1:EsiD+7Fx+bRckKWZXnAXRKKetm1WuzPagH4iOSC8x58=
 k8s.io/code-generator v0.0.0-20181114232248-ae218e241252/go.mod h1:IPqxl/YHk05nodzupwjke6ctMjyNRdV2zZ5/j3/F204=
+k8s.io/code-generator v0.18.3 h1:5H57pYEbkMMXCLKD16YQH3yDPAbVLweUsB1M3m70D1c=
 k8s.io/code-generator v0.18.3/go.mod h1:TgNEVx9hCyPGpdtCWA34olQYLkh3ok9ar7XfSsr8b6c=
 k8s.io/gengo v0.0.0-20181106084056-51747d6e00da/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190907103519-ebc107f98eab/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.0.0-20190306015804-8e90cee79f82/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -282,4 +282,3 @@ func Install(k8sNamespace, namePrefix string) {
 
 	glog.Infof("all resources created successfully")
 }
-

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 Red Hat, Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	DownwardAPIMountPath   = "/etc/podnetinfo"
+	AnnotationsPath        = "annotations"
+	LabelsPath             = "labels"
+	Hugepages1GRequestPath = "hugepages_1G_request"
+	Hugepages2MRequestPath = "hugepages_2M_request"
+	Hugepages1GLimitPath   = "hugepages_1G_limit"
+	Hugepages2MLimitPath   = "hugepages_2M_limit"
+)

--- a/pkg/webhook/tlsutils.go
+++ b/pkg/webhook/tlsutils.go
@@ -87,7 +87,7 @@ func NewTlsKeypairReloader(certPath, keyPath string) (*tlsKeypairReloader, error
 func NewClientCertPool(clientCaPaths *ClientCAFlags, insecure bool) (*clientCertPool, error) {
 	pool := &clientCertPool{
 		certPaths: clientCaPaths,
-		insecure: insecure,
+		insecure:  insecure,
 	}
 	if !pool.insecure {
 		if err := pool.Load(); err != nil {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -74,7 +74,7 @@ func readAdmissionReview(req *http.Request, w http.ResponseWriter) (*v1beta1.Adm
 	var body []byte
 
 	if req.Body != nil {
-		req.Body = http.MaxBytesReader(w, req.Body, 1 << 20)
+		req.Body = http.MaxBytesReader(w, req.Body, 1<<20)
 		if data, err := ioutil.ReadAll(req.Body); err == nil {
 			body = data
 		}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -26,8 +26,9 @@ import (
 	"github.com/golang/glog"
 	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/pkg/errors"
-	"gopkg.in/intel/multus-cni.v3/types"
+	multus "gopkg.in/intel/multus-cni.v3/types"
 
+	"github.com/intel/network-resources-injector/pkg/types"
 	"k8s.io/api/admission/v1beta1"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -45,13 +46,20 @@ type jsonPatchOperation struct {
 	Value     interface{} `json:"value,omitempty"`
 }
 
+type hugepageResourceData struct {
+	ResourceName  string
+	ContainerName string
+	Path          string
+}
+
 const (
 	networksAnnotationKey = "k8s.v1.cni.cncf.io/networks"
 )
 
 var (
-	clientset        kubernetes.Interface
-	resourceNameKeys []string
+	clientset             kubernetes.Interface
+	injectHugepageDownApi bool
+	resourceNameKeys      []string
 )
 
 func prepareAdmissionReviewResponse(allowed bool, message string, ar *v1beta1.AdmissionReview) error {
@@ -220,8 +228,8 @@ func toSafeJsonPatchKey(in string) string {
 	return out
 }
 
-func parsePodNetworkSelections(podNetworks, defaultNamespace string) ([]*types.NetworkSelectionElement, error) {
-	var networkSelections []*types.NetworkSelectionElement
+func parsePodNetworkSelections(podNetworks, defaultNamespace string) ([]*multus.NetworkSelectionElement, error) {
+	var networkSelections []*multus.NetworkSelectionElement
 
 	if len(podNetworks) == 0 {
 		err := errors.New("empty string passed as network selection elements list")
@@ -257,9 +265,9 @@ func parsePodNetworkSelections(podNetworks, defaultNamespace string) ([]*types.N
 	return networkSelections, nil
 }
 
-func parsePodNetworkSelectionElement(selection, defaultNamespace string) (*types.NetworkSelectionElement, error) {
+func parsePodNetworkSelectionElement(selection, defaultNamespace string) (*multus.NetworkSelectionElement, error) {
 	var namespace, name, netInterface string
-	var networkSelectionElement *types.NetworkSelectionElement
+	var networkSelectionElement *multus.NetworkSelectionElement
 
 	units := strings.Split(selection, "/")
 	switch len(units) {
@@ -299,7 +307,7 @@ func parsePodNetworkSelectionElement(selection, defaultNamespace string) (*types
 		}
 	}
 
-	networkSelectionElement = &types.NetworkSelectionElement{
+	networkSelectionElement = &multus.NetworkSelectionElement{
 		Namespace:        namespace,
 		Name:             name,
 		InterfaceRequest: netInterface,
@@ -348,22 +356,36 @@ func patchEmptyResources(patch []jsonPatchOperation, containerIndex uint, key st
 	return patch
 }
 
-func addVolDownwardAPI(patch []jsonPatchOperation) []jsonPatchOperation {
+func addVolDownwardAPI(patch []jsonPatchOperation, hugepageResourceList []hugepageResourceData) []jsonPatchOperation {
 	labels := corev1.ObjectFieldSelector{
 		FieldPath: "metadata.labels",
 	}
 	dAPILabels := corev1.DownwardAPIVolumeFile{
-		Path:     "labels",
+		Path:     types.LabelsPath,
 		FieldRef: &labels,
 	}
 	annotations := corev1.ObjectFieldSelector{
 		FieldPath: "metadata.annotations",
 	}
 	dAPIAnnotations := corev1.DownwardAPIVolumeFile{
-		Path:     "annotations",
+		Path:     types.AnnotationsPath,
 		FieldRef: &annotations,
 	}
 	dAPIItems := []corev1.DownwardAPIVolumeFile{dAPILabels, dAPIAnnotations}
+
+	for _, hugepageResource := range hugepageResourceList {
+		hugepageSelector := corev1.ResourceFieldSelector{
+			Resource:      hugepageResource.ResourceName,
+			ContainerName: hugepageResource.ContainerName,
+			Divisor:       *resource.NewQuantity(1*1024*1024, resource.BinarySI),
+		}
+		dAPIHugepage := corev1.DownwardAPIVolumeFile{
+			Path:             hugepageResource.Path,
+			ResourceFieldRef: &hugepageSelector,
+		}
+		dAPIItems = append(dAPIItems, dAPIHugepage)
+	}
+
 	dAPIVolSource := corev1.DownwardAPIVolumeSource{
 		Items: dAPIItems,
 	}
@@ -389,7 +411,7 @@ func addVolumeMount(patch []jsonPatchOperation) []jsonPatchOperation {
 	vm := corev1.VolumeMount{
 		Name:      "podnetinfo",
 		ReadOnly:  false,
-		MountPath: "/etc/podnetinfo",
+		MountPath: types.DownwardAPIMountPath,
 	}
 
 	patch = append(patch, jsonPatchOperation{
@@ -401,9 +423,9 @@ func addVolumeMount(patch []jsonPatchOperation) []jsonPatchOperation {
 	return patch
 }
 
-func createVolPatch(patch []jsonPatchOperation) []jsonPatchOperation {
+func createVolPatch(patch []jsonPatchOperation, hugepageResourceList []hugepageResourceData) []jsonPatchOperation {
 	patch = addVolumeMount(patch)
-	patch = addVolDownwardAPI(patch)
+	patch = addVolDownwardAPI(patch, hugepageResourceList)
 	return patch
 }
 
@@ -504,7 +526,52 @@ func MutateHandler(w http.ResponseWriter, req *http.Request) {
 				})
 			}
 
-			patch = createVolPatch(patch)
+			// Determine if hugepages are being requested for a given container,
+			// and if so, expose the value to the container via Downward API.
+			var hugepageResourceList []hugepageResourceData
+			glog.Infof("injectHugepageDownApi=%v", injectHugepageDownApi)
+			if injectHugepageDownApi {
+				for _, container := range pod.Spec.Containers {
+					if len(container.Resources.Requests) != 0 {
+						if quantity, exists := container.Resources.Requests["hugepages-1Gi"]; exists && quantity.IsZero() == false {
+							hugepageResource := hugepageResourceData{
+								ResourceName:  "requests.hugepages-1Gi",
+								ContainerName: container.Name,
+								Path:          types.Hugepages1GRequestPath,
+							}
+							hugepageResourceList = append(hugepageResourceList, hugepageResource)
+						}
+						if quantity, exists := container.Resources.Requests["hugepages-2Mi"]; exists && quantity.IsZero() == false {
+							hugepageResource := hugepageResourceData{
+								ResourceName:  "requests.hugepages-2Mi",
+								ContainerName: container.Name,
+								Path:          types.Hugepages2MRequestPath,
+							}
+							hugepageResourceList = append(hugepageResourceList, hugepageResource)
+						}
+					}
+					if len(container.Resources.Limits) != 0 {
+						if quantity, exists := container.Resources.Limits["hugepages-1Gi"]; exists && quantity.IsZero() == false {
+							hugepageResource := hugepageResourceData{
+								ResourceName:  "limits.hugepages-1Gi",
+								ContainerName: container.Name,
+								Path:          types.Hugepages1GLimitPath,
+							}
+							hugepageResourceList = append(hugepageResourceList, hugepageResource)
+						}
+						if quantity, exists := container.Resources.Limits["hugepages-2Mi"]; exists && quantity.IsZero() == false {
+							hugepageResource := hugepageResourceData{
+								ResourceName:  "limits.hugepages-2Mi",
+								ContainerName: container.Name,
+								Path:          types.Hugepages2MLimitPath,
+							}
+							hugepageResourceList = append(hugepageResourceList, hugepageResource)
+						}
+					}
+				}
+			}
+
+			patch = createVolPatch(patch, hugepageResourceList)
 			glog.Infof("patch after all mutations: %v", patch)
 
 			patchBytes, _ := json.Marshal(patch)
@@ -553,4 +620,10 @@ func SetupInClusterClient() {
 	if err != nil {
 		glog.Fatal(err)
 	}
+}
+
+// SetInjectHugepageDownApi sets a flag to indicate whether or not to inject the
+// hugepage request and limit for the Downward API.
+func SetInjectHugepageDownApi(hugepageFlag bool) {
+	injectHugepageDownApi = hugepageFlag
 }


### PR DESCRIPTION
In Kubernetes 1.20, an alpha feature was added to expose the requested
hugepages to the container via the Downward API. This is feature is
disabled by default. If enabled when Kubernetes is deployed via
FEATURE_GATES="DownwardAPIHugePages=true", then Network Resource
Injector can be used to mutate the pod spec to publish the hugepage
data to the container. Since the Kubernetes feature is disabled by
default, added a configuration parameter to turn on the Network
Resource Injector code.

NOTE: The code loops through all containers in a pod and if multiple
containers are requesting hugepages, then the Downward API fields
are requested for each containers. There is an issue where the same
value is placed in both containers, even if different values are requested.
Think it is a K8s issue and still investigating.

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>