### PR TITLE
Fix broken makefile test option and move logic to sh file

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,6 @@
-# Copyright (c) 2018 Intel Corporation
+#!/bin/bash
+
+# Copyright (c) 2020 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default :
-	scripts/build.sh
+# Note: Execute only from the package root directory or top-level Makefile!
 
-image :
-	scripts/build-image.sh
+set -ex
 
-test :
-	scripts/test.sh
-
-vendor :
-	go mod tidy && go mod vendor
+time=$(date +'%Y-%m-%d_%H-%M-%S')
+filePath="/tmp/go-cover.$time.tmp"
+echo "Coverage profile file path: $filePath"
+go test -coverprofile="$filePath" ./...
+go tool cover -html="$filePath"


### PR DESCRIPTION
Fixes: #52 
Previously, environment variable was not getting utilized
and causing errors when make test option was executed.

This patch also changes the intermediate coverage profile
file name to a date instead of using the process ID.

This patch moves the logic to shell file so it can be
extended in the future.

Signed-off-by: Martin Kennelly <martin.kennelly@intel.com>


$ shellcheck test.sh
No issues detected!


