### PR TITLE
Remove buildmode=pie

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,5 +29,5 @@ export GOBIN=${PWD}/bin
 export CGO_ENABLED=0
 export GO15VENDOREXPERIMENT=1
 
-go install -ldflags "-s -w" -buildmode=pie -tags no_openssl "$@" ${REPO_PATH}/cmd/installer
-go install -ldflags "-s -w" -buildmode=pie -tags no_openssl "$@" ${REPO_PATH}/cmd/webhook
+go install -ldflags "-s -w" -tags no_openssl "$@" ${REPO_PATH}/cmd/installer
+go install -ldflags "-s -w" -tags no_openssl "$@" ${REPO_PATH}/cmd/webhook


### PR DESCRIPTION
By using buildmode=pie dynamic linking is activated and as a
consequence, the binary depends on /lib/ld-musl-x86_64.so.1,
which makes it work only in Alpine

Besides, this is at odds with CGO_ENABLED=0 option which is
part of the script

Signed-off-by: Manuel Buil <mbuil@suse.com>