### PR TITLE
Add contact us section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,7 @@ spec:
  nodeSelector:
    master: eno3
 ```
+
+## Contact Us
+
+For any questions about Network Resources Injector, feel free to ask a question in #network-resources-injector in [NPWG slack](https://npwg-team.slack.com/), or open up a GitHub issue.


### PR DESCRIPTION
Added new channel in rebranded NPWG slack (formerly intel-corp slack). Polling for interest if we should add this to our README.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>