### PR TITLE
Fix auto-invite to NPWG slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ spec:
 
 ## Contact Us
 
-For any questions about Network Resources Injector, feel free to ask a question in #network-resources-injector in [NPWG slack](https://npwg-team.slack.com/), or open up a GitHub issue.
+For any questions about Network Resources Injector, feel free to ask a question in #network-resources-injector in [NPWG slack](https://npwg-team.slack.com/), or open up a GitHub issue. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).


### PR DESCRIPTION
Re-adding NPWG slack auto invite mechanism. Non-Intel users
need mechanism to join NPWG slack.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

I misunderstood slacks invite mechanism for non-Intel users. Non-Intel users require invite. Re-adding invite mechanism.

I attempted to change URL of invite mechanism but failed. Slack only grands auto invite rights to enterprise workspaces. See here outsideris/slack-invite-automation#146
Currently, the intel-corp.heroku.com app relies on slacks legacy token mechanism to accomplish this. This will fail in the future when legacy tokens are deprecated. I think this should be discussed at NPWG level but in the mean time, I propose re-adding auto invite mechanism.