### PR TITLE
Add constraints to pod spec

### DIFF
--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -75,6 +75,13 @@ spec:
     volumeMounts:
     - name: tls
       mountPath: /etc/tls
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "250m"
+      limits:
+        memory: "200Mi"
+        cpu: "500m"
   volumes:
   - name: tls
     emptyDir: {}

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -72,6 +72,9 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
     volumeMounts:
     - name: tls
       mountPath: /etc/tls

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -20,6 +20,10 @@ metadata:
   name: network-resources-injector
   namespace: kube-system
 spec:
+  securityContext:
+    runAsUser: 10000
+    runAsGroup: 10000
+    runAsNonRoot: true
   serviceAccount: network-resources-injector-sa
   containers:
   - name: webhook-server
@@ -39,8 +43,6 @@ spec:
         fieldRef:
           fieldPath: metadata.namespace
     securityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
       capabilities:
         drop:
           - ALL
@@ -68,8 +70,6 @@ spec:
     - -namespace=kube-system
     - -alsologtostderr
     securityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
     volumeMounts:
     - name: tls
       mountPath: /etc/tls

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -68,8 +68,10 @@ spec:
     args:
     - -name=network-resources-injector
     - -namespace=kube-system
-    - -alsologtostderr
+    - -logtostderr
     securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
     volumeMounts:
     - name: tls
       mountPath: /etc/tls


### PR DESCRIPTION
Small changes to pod spec to improve security
See commits.

I wanted to group ```allowPrivilegeEscalation``` & ```readOnlyRootFilesystem``` at the "pod level" ```securityContext``` (ln 23) but it will not allow me. 