### PR TITLE
Add github workflows for image creation

### DIFF
--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,0 +1,33 @@
+name: "Push images on merge to master"
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-push-image-nri:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push network-resources-injector
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./Dockerfile

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,0 +1,39 @@
+name: "Push images on release"
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build-and-push-image-nri:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push network-resources-injector
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: ./Dockerfile


### PR DESCRIPTION
With a push to master, a new image will be built and pushed to
github container registry at URL:
ghcr.io/k8snetworkplumbingwg/network-resources-injector:${tag}
The accompanying tag can wither be sha or latest.

With a creation of a new release and associated tag which starts
with 'v', a new image will be built and pushed to github
container registry at URL:
ghcr.io/k8snetworkplumbingwg/network-resources-injector:${tag}
The accompanying tag will start with 'v' and the version number.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>