### PR TITLE
Add access rights to ConfigMap for NRI

### DIFF
--- a/deployments/auth.yaml
+++ b/deployments/auth.yaml
@@ -99,6 +99,18 @@ rules:
   - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: network-resources-injector-configmaps
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: network-resources-injector-role-binding
@@ -158,6 +170,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: network-resources-injector-service
+subjects:
+- kind: ServiceAccount
+  name: network-resources-injector-sa
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: network-resources-injector-configmaps-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: network-resources-injector-configmaps
 subjects:
 - kind: ServiceAccount
   name: network-resources-injector-sa

--- a/deployments/auth.yaml
+++ b/deployments/auth.yaml
@@ -108,7 +108,7 @@ rules:
   resources:
   - configmaps
   verbs:
-  - '*'
+  - 'get'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR fixes https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/85

It adds ClusterRole and ClusterRoleBinding to allow NRI service access to ConfigMap, This access is needed by 'User Defined Injections` feature.