### PR TITLE
Increase glog level for reloading certificate

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -157,11 +157,11 @@ func main() {
 			if !ok {
 				continue
 			}
-			glog.Infof("watcher event: %v", event)
+			glog.V(2).Infof("watcher event: %v", event)
 			mask := fsnotify.Create | fsnotify.Rename | fsnotify.Remove |
 				fsnotify.Write | fsnotify.Chmod
 			if (event.Op & mask) != 0 {
-				glog.Infof("modified file: %v", event.Name)
+				glog.V(2).Infof("modified file: %v", event.Name)
 				if event.Name == *cert {
 					certUpdated = true
 				}

--- a/pkg/webhook/tlsutils.go
+++ b/pkg/webhook/tlsutils.go
@@ -53,7 +53,7 @@ func (keyPair *tlsKeypairReloader) Reload() error {
 	if err != nil {
 		return err
 	}
-	glog.Infof("cetificate reloaded")
+	glog.V(2).Infof("cetificate reloaded")
 	keyPair.certMutex.Lock()
 	defer keyPair.certMutex.Unlock()
 	keyPair.cert = &newCert


### PR DESCRIPTION
Certificate reloading messages are printed every
few minutes when there is a configMap refresh.
This commit suppresses those messages by lifting
the log level to V(2).

Signed-off-by: Zenghui Shi <zshi@redhat.com>