### PR TITLE
Add controlSwitches package to be able to toggle feature state at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
       * [Disable adding client CAs to server TLS endpoint](#disable-adding-client-cas-to-server-tls-endpoint)
       * [Client CAs](#client-cas)
    * [Additional features](#additional-features)
+      * [Features control switches](#features-control-switches)
       * [Expose Hugepages via Downward API](#expose-hugepages-via-downward-api)
       * [Node Selector](#node-selector)
       * [User Defined Injections](#user-defined-injections)
@@ -141,6 +142,46 @@ By default, we consume the client CA from the Kubernetes service account secrets
 If you wish to consume a client CA from a different location, please specify flag ```--client-ca``` with a valid path. If you wish to add more than one client CA, repeat this flag multiple times. If ```--client-ca``` is defined, the default client CA from the service account secrets directory will not be consumed.
 
 ## Additional features
+All additional Network Resource Injector features can be enabled by passing command line arguments to executable. It can be done by modification of arguments passed to webhook. Example yaml with deployment is here [server.yaml](deployments/server.yaml)
+
+Currently supported arguments are below. If needed, detailed description is available below in sub points. ConfigMap with runtime configuration is described below in point [Features control switches](#features-control-switches).
+
+|Argument|Default|Description|Can be set via ConfigMap|
+|---|---|---|---|
+|port|8443|The port on which to serve.|NO|
+|bind-address|0.0.0.0|The IP address on which to listen for the --port port.|NO|
+|tls-cert-file|cert.pem|File containing the default x509 Certificate for HTTPS.|NO|
+|tls-private-key-file|key.pem|File containing the default x509 private key matching --tls-cert-file.|NO|
+|insecure|false|Disable adding client CA to server TLS endpoint|NO|
+|client-ca|""|File containing client CA. This flag is repeatable if more than one client CA needs to be added to server|NO|
+|injectHugepageDownApi|false|Enable hugepage requests and limits into Downward API.|YES|
+|network-resource-name-keys|k8s.v1.cni.cncf.io/resourceName|comma separated resource name keys|YES|
+|honor-resources|false|Honor the existing requested resources requests & limits|YES|
+|user-injections|true|Enable / disable user defined injections|YES|
+
+### Features control switches
+It is possible to control some features of Network Resource Injector with runtime configuration. NRI is watching for a ConfigMap with name **nri-control-switches** that should be available in the same namespace as NRI (default is kube-system). Below is example with full configuration that sets all features to disable state. Not all values have to be defined. User can toggle only one feature leaving others in default state. By default state, one should understand state set during webhook initialization. Could be a state set by CLI argument, default argument embedded in code or environment variable.
+
+```
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-control-switches
+  namespace: kube-system
+data:
+  config.json: |
+    {
+      "features": {
+        "enableHugePageDownApi": false,
+        "enableHonorExistingResources": false,
+        "enableCustomizedInjection": false
+      }
+    }
+
+```
+
+Set feature state is available as long as ConfigMap exists. Webhook checks for map update every 30 seconds. Please keep in mind that runtime configuration settings override all other settings. They have the highest priority.
+
 ### Expose Hugepages via Downward API
 In Kubernetes 1.20, an alpha feature was added to expose the requested hugepages to the container via the Downward API.
 Being alpha, this feature is disabled in Kubernetes by default.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Currently supported arguments are below. If needed, detailed description is avai
 |injectHugepageDownApi|false|Enable hugepage requests and limits into Downward API.|YES|
 |network-resource-name-keys|k8s.v1.cni.cncf.io/resourceName|comma separated resource name keys|YES|
 |honor-resources|false|Honor the existing requested resources requests & limits|YES|
-|user-injections|true|Enable / disable user defined injections|YES|
 
 ### Features control switches
 It is possible to control some features of Network Resource Injector with runtime configuration. NRI is watching for a ConfigMap with name **nri-control-switches** that should be available in the same namespace as NRI (default is kube-system). Below is example with full configuration that sets all features to disable state. Not all values have to be defined. User can toggle only one feature leaving others in default state. By default state, one should understand state set during webhook initialization. Could be a state set by CLI argument, default argument embedded in code or environment variable.
@@ -173,8 +172,7 @@ data:
     {
       "features": {
         "enableHugePageDownApi": false,
-        "enableHonorExistingResources": false,
-        "enableCustomizedInjection": false
+        "enableHonorExistingResources": false
       }
     }
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -25,13 +25,13 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
-	netcache "github.com/k8snetworkplumbingwg/network-resources-injector/pkg/tools"
-	"k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/controlswitches"
-	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/webhook"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/controlswitches"
+	netcache "github.com/k8snetworkplumbingwg/network-resources-injector/pkg/tools"
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/webhook"
 )
 
 const (

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -26,6 +26,9 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	netcache "github.com/k8snetworkplumbingwg/network-resources-injector/pkg/tools"
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/controlswitches"
 	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/webhook"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,28 +37,40 @@ import (
 const (
 	defaultClientCa               = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	userDefinedInjectionConfigMap = "nri-user-defined-injections"
+	controlSwitchesConfigMap      = "nri-control-switches"
 )
 
 func main() {
 	var namespace string
 	var clientCAPaths webhook.ClientCAFlags
+
 	/* load configuration */
 	port := flag.Int("port", 8443, "The port on which to serve.")
 	address := flag.String("bind-address", "0.0.0.0", "The IP address on which to listen for the --port port.")
 	cert := flag.String("tls-cert-file", "cert.pem", "File containing the default x509 Certificate for HTTPS.")
 	key := flag.String("tls-private-key-file", "key.pem", "File containing the default x509 private key matching --tls-cert-file.")
 	insecure := flag.Bool("insecure", false, "Disable adding client CA to server TLS endpoint --insecure")
-	injectHugepageDownApi := flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
 	flag.Var(&clientCAPaths, "client-ca", "File containing client CA. This flag is repeatable if more than one client CA needs to be added to server")
-	resourceNameKeys := flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
-	resourcesHonorFlag := flag.Bool("honor-resources", false, "Honor the existing requested resources requests & limits --honor-resources")
+
+	// do initialization of control switches flags
+	controlSwitches := controlswitches.SetupControlSwitchesFlags()
+
+	// at the end when all flags are declared parse it
 	flag.Parse()
+
+	// initialize all control switches structures
+	controlSwitches.InitControlSwitches()
+	glog.Infof("controlSwitches: %+v", *controlSwitches)
 
 	if *port < 1024 || *port > 65535 {
 		glog.Fatalf("invalid port number. Choose between 1024 and 65535")
 	}
 
-	if *address == "" || *cert == "" || *key == "" || *resourceNameKeys == "" {
+	if !controlSwitches.IsResourcesNameEnabled() {
+		glog.Fatalf("Input argument for resourceName cannot be empty.")
+	}
+
+	if *address == "" || *cert == "" || *key == "" {
 		glog.Fatalf("input argument(s) not defined correctly")
 	}
 
@@ -82,14 +97,8 @@ func main() {
 	/* init API client */
 	clientset := webhook.SetupInClusterClient()
 
-	webhook.SetInjectHugepageDownApi(*injectHugepageDownApi)
-
-	webhook.SetHonorExistingResources(*resourcesHonorFlag)
-
-	err = webhook.SetResourceNameKeys(*resourceNameKeys)
-	if err != nil {
-		glog.Fatalf("error in setting resource name keys: %s", err.Error())
-	}
+	// initialize webhook with controlSwitches
+	webhook.SetControlSwitches(controlSwitches)
 
 	//initialize webhook with cache
 	netAnnotationCache := netcache.Create()
@@ -189,14 +198,27 @@ func main() {
 			glog.Infof("watcher error: %v", err)
 		case <-time.After(30 * time.Second):
 			cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(
-				context.Background(), userDefinedInjectionConfigMap, metav1.GetOptions{})
+				context.Background(), controlSwitchesConfigMap, metav1.GetOptions{})
 			if err != nil {
+				glog.Warningf("Error within control switches map %s", err.Error())
 				if !errors.IsNotFound(err) {
-					glog.Warningf("Failed to get configmap for user-defined injections: %v", err)
-					continue
+					glog.Info("Map with runtime configuration not available using default / CLI settings")
 				}
 			}
-			webhook.SetCustomizedInjections(cm)
+			// has to be called each time because we need to restore default config when map is empty
+			controlSwitches.ProcessControlSwitchesConfigMap(cm)
+
+			if controlSwitches.IsCustomizedInjectionsEnabled() {
+				cm, err = clientset.CoreV1().ConfigMaps(namespace).Get(
+					context.Background(), userDefinedInjectionConfigMap, metav1.GetOptions{})
+				if err != nil {
+					if !errors.IsNotFound(err) {
+						glog.Warningf("Failed to get configmap for user-defined injections: %v", err)
+						continue
+					}
+				}
+				webhook.SetCustomizedInjections(cm)
+			}
 		}
 	}
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -208,17 +208,15 @@ func main() {
 			// has to be called each time because we need to restore default config when map is empty
 			controlSwitches.ProcessControlSwitchesConfigMap(cm)
 
-			if controlSwitches.IsCustomizedInjectionsEnabled() {
-				cm, err = clientset.CoreV1().ConfigMaps(namespace).Get(
-					context.Background(), userDefinedInjectionConfigMap, metav1.GetOptions{})
-				if err != nil {
-					if !errors.IsNotFound(err) {
-						glog.Warningf("Failed to get configmap for user-defined injections: %v", err)
-						continue
-					}
+			cm, err = clientset.CoreV1().ConfigMaps(namespace).Get(
+				context.Background(), userDefinedInjectionConfigMap, metav1.GetOptions{})
+			if err != nil {
+				if !errors.IsNotFound(err) {
+					glog.Warningf("Failed to get configmap for user-defined injections: %v", err)
+					continue
 				}
-				webhook.SetCustomizedInjections(cm)
 			}
+			webhook.SetCustomizedInjections(cm)
 		}
 	}
 

--- a/pkg/controlswitches/controlswitches.go
+++ b/pkg/controlswitches/controlswitches.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlswitches
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	// control switch keys
+	controlSwitchesFileKey = "config.json"
+	controlSwitchesMainKey = "features"
+
+	// enableHugePageDownAPIKey feature name
+	enableHugePageDownAPIKey = "enableHugePageDownApi"
+	// enableHonorExistingResourcesKey feature name
+	enableHonorExistingResourcesKey = "enableHonorExistingResources"
+	// enableCustomizedInjectionKey feature name
+	enableCustomizedInjectionKey = "enableCustomizedInjection"
+)
+
+// controlSwitchesStates - depicts possible feature states
+type controlSwitchesStates struct {
+	active  bool
+	initial bool
+}
+
+// setActiveToInitialState - set active state to the initial state set during initialization
+func (state *controlSwitchesStates) setActiveToInitialState() {
+	state.active = state.initial
+}
+
+// setActiveState - set active state to the passed value
+func (state *controlSwitchesStates) setActiveState(value bool) {
+	state.active = value
+}
+
+type ControlSwitches struct {
+	// pointers to command line arguments
+	injectHugepageDownAPI *bool
+	resourceNameKeysFlag  *string
+	resourcesHonorFlag    *bool
+	userInjectionFlag     *bool
+
+	configuration    map[string]controlSwitchesStates
+	resourceNameKeys []string
+	isValid          bool
+}
+
+// SetupControlSwitchesFlags - setup all control switches flags that can be set as command line NRI arguments
+// :return pointer to the structure that should be initialized with InitControlSwitches
+func SetupControlSwitchesFlags() *ControlSwitches {
+	var initFlags ControlSwitches
+
+	initFlags.injectHugepageDownAPI = flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
+	initFlags.resourceNameKeysFlag = flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
+	initFlags.resourcesHonorFlag = flag.Bool("honor-resources", false, "Honor the existing requested resources requests & limits --honor-resources")
+	initFlags.userInjectionFlag = flag.Bool("user-injections", true, "Enable / disable user defined injections --user-injections")
+
+	return &initFlags
+}
+
+// InitControlSwitches - initialize internal control switches structures based on command line arguments
+func (switches *ControlSwitches) InitControlSwitches() {
+	switches.configuration = make(map[string]controlSwitchesStates)
+
+	state := controlSwitchesStates{initial: *switches.injectHugepageDownAPI, active: *switches.injectHugepageDownAPI}
+	switches.configuration[enableHugePageDownAPIKey] = state
+
+	state = controlSwitchesStates{initial: *switches.resourcesHonorFlag, active: *switches.resourcesHonorFlag}
+	switches.configuration[enableHonorExistingResourcesKey] = state
+
+	state = controlSwitchesStates{initial: *switches.userInjectionFlag, active: *switches.userInjectionFlag}
+	switches.configuration[enableCustomizedInjectionKey] = state
+
+	switches.resourceNameKeys = setResourceNameKeys(*switches.resourceNameKeysFlag)
+
+	switches.isValid = true
+}
+
+// setResourceNameKeys extracts resources from a string and add them to resourceNameKeys array
+func setResourceNameKeys(keys string) []string {
+	var resourceNameKeys []string
+
+	for _, resourceNameKey := range strings.Split(keys, ",") {
+		resourceNameKey = strings.TrimSpace(resourceNameKey)
+		resourceNameKeys = append(resourceNameKeys, resourceNameKey)
+	}
+
+	return resourceNameKeys
+}
+
+func (switches *ControlSwitches) GetResourceNameKeys() []string {
+	return switches.resourceNameKeys
+}
+
+func (switches *ControlSwitches) IsHugePagedownAPIEnabled() bool {
+	return switches.configuration[enableHugePageDownAPIKey].active
+}
+
+func (switches *ControlSwitches) IsHonorExistingResourcesEnabled() bool {
+	return switches.configuration[enableHonorExistingResourcesKey].active
+}
+
+func (switches *ControlSwitches) IsCustomizedInjectionsEnabled() bool {
+	return switches.configuration[enableCustomizedInjectionKey].active
+}
+
+func (switches *ControlSwitches) IsResourcesNameEnabled() bool {
+	return len(*switches.resourceNameKeysFlag) > 0
+}
+
+// IsValid returns true when ControlSwitches structure was initialized, false otherwise
+func (switches *ControlSwitches) IsValid() bool {
+	return switches.isValid
+}
+
+// GetAllFeaturesState returns string with information if feature is active or not
+func (switches *ControlSwitches) GetAllFeaturesState() string {
+	var output string
+
+	output = fmt.Sprintf("HugePageInject: %t", switches.IsHugePagedownAPIEnabled())
+	output = output + " / " + fmt.Sprintf("HonorExistingResources: %t", switches.IsHonorExistingResourcesEnabled())
+	output = output + " / " + fmt.Sprintf("Custom Injections: %t", switches.IsCustomizedInjectionsEnabled())
+	output = output + " / " + fmt.Sprintf("EnableResourceNames: %t", switches.IsResourcesNameEnabled())
+
+	return output
+}
+
+// setAllFeaturesToInitialState - reset feature state to initial one set during NRI initialization
+func (switches *ControlSwitches) setAllFeaturesToInitialState() {
+	state := switches.configuration[enableHugePageDownAPIKey]
+	state.setActiveToInitialState()
+	switches.configuration[enableHugePageDownAPIKey] = state
+
+	state = switches.configuration[enableHonorExistingResourcesKey]
+	state.setActiveToInitialState()
+	switches.configuration[enableHonorExistingResourcesKey] = state
+
+	state = switches.configuration[enableCustomizedInjectionKey]
+	state.setActiveToInitialState()
+	switches.configuration[enableCustomizedInjectionKey] = state
+}
+
+// setFeatureToState set given feature to the state defined in the map object
+func (switches *ControlSwitches) setFeatureToState(featureName string, switchObj map[string]bool) {
+	if featureState, available := switchObj[featureName]; available {
+		state := switches.configuration[featureName]
+		state.setActiveState(featureState)
+		switches.configuration[featureName] = state
+	} else {
+		state := switches.configuration[featureName]
+		state.setActiveToInitialState()
+		switches.configuration[featureName] = state
+	}
+}
+
+// ProcessControlSwitchesConfigMap sets on the fly control switches
+// :param controlSwitchesCm - Kubernetes ConfigMap with control switches definition
+func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitchesCm *corev1.ConfigMap) {
+	var err error
+	if v, fileExists := controlSwitchesCm.Data[controlSwitchesFileKey]; fileExists {
+		var obj map[string]json.RawMessage
+		err = json.Unmarshal([]byte(v), &obj)
+
+		if err != nil {
+			glog.Warningf("Error during json unmarshal %v", err)
+			switches.setAllFeaturesToInitialState()
+			return
+		}
+
+		if controlSwitches, mainExists := obj[controlSwitchesMainKey]; mainExists {
+			var switchObj map[string]bool
+			err = json.Unmarshal(controlSwitches, &switchObj)
+
+			if err != nil {
+				glog.Warningf("Unable to unmarshal [%s] from configmap, err: %v", controlSwitchesMainKey, err)
+				switches.setAllFeaturesToInitialState()
+				return
+			}
+
+			switches.setFeatureToState(enableHugePageDownAPIKey, switchObj)
+			switches.setFeatureToState(enableHonorExistingResourcesKey, switchObj)
+			switches.setFeatureToState(enableCustomizedInjectionKey, switchObj)
+		} else {
+			glog.Warningf("Map does not contains [%s]", controlSwitchesMainKey)
+		}
+	} else {
+		glog.Warningf("Map does not contains [%s]", controlSwitchesFileKey)
+	}
+}

--- a/pkg/controlswitches/controlswitches.go
+++ b/pkg/controlswitches/controlswitches.go
@@ -33,8 +33,6 @@ const (
 	enableHugePageDownAPIKey = "enableHugePageDownApi"
 	// enableHonorExistingResourcesKey feature name
 	enableHonorExistingResourcesKey = "enableHonorExistingResources"
-	// enableCustomizedInjectionKey feature name
-	enableCustomizedInjectionKey = "enableCustomizedInjection"
 )
 
 // controlSwitchesStates - depicts possible feature states
@@ -58,7 +56,6 @@ type ControlSwitches struct {
 	injectHugepageDownAPI *bool
 	resourceNameKeysFlag  *string
 	resourcesHonorFlag    *bool
-	userInjectionFlag     *bool
 
 	configuration    map[string]controlSwitchesStates
 	resourceNameKeys []string
@@ -73,7 +70,6 @@ func SetupControlSwitchesFlags() *ControlSwitches {
 	initFlags.injectHugepageDownAPI = flag.Bool("injectHugepageDownApi", false, "Enable hugepage requests and limits into Downward API.")
 	initFlags.resourceNameKeysFlag = flag.String("network-resource-name-keys", "k8s.v1.cni.cncf.io/resourceName", "comma separated resource name keys --network-resource-name-keys.")
 	initFlags.resourcesHonorFlag = flag.Bool("honor-resources", false, "Honor the existing requested resources requests & limits --honor-resources")
-	initFlags.userInjectionFlag = flag.Bool("user-injections", true, "Enable / disable user defined injections --user-injections")
 
 	return &initFlags
 }
@@ -87,9 +83,6 @@ func (switches *ControlSwitches) InitControlSwitches() {
 
 	state = controlSwitchesStates{initial: *switches.resourcesHonorFlag, active: *switches.resourcesHonorFlag}
 	switches.configuration[enableHonorExistingResourcesKey] = state
-
-	state = controlSwitchesStates{initial: *switches.userInjectionFlag, active: *switches.userInjectionFlag}
-	switches.configuration[enableCustomizedInjectionKey] = state
 
 	switches.resourceNameKeys = setResourceNameKeys(*switches.resourceNameKeysFlag)
 
@@ -120,10 +113,6 @@ func (switches *ControlSwitches) IsHonorExistingResourcesEnabled() bool {
 	return switches.configuration[enableHonorExistingResourcesKey].active
 }
 
-func (switches *ControlSwitches) IsCustomizedInjectionsEnabled() bool {
-	return switches.configuration[enableCustomizedInjectionKey].active
-}
-
 func (switches *ControlSwitches) IsResourcesNameEnabled() bool {
 	return len(*switches.resourceNameKeysFlag) > 0
 }
@@ -139,7 +128,6 @@ func (switches *ControlSwitches) GetAllFeaturesState() string {
 
 	output = fmt.Sprintf("HugePageInject: %t", switches.IsHugePagedownAPIEnabled())
 	output = output + " / " + fmt.Sprintf("HonorExistingResources: %t", switches.IsHonorExistingResourcesEnabled())
-	output = output + " / " + fmt.Sprintf("Custom Injections: %t", switches.IsCustomizedInjectionsEnabled())
 	output = output + " / " + fmt.Sprintf("EnableResourceNames: %t", switches.IsResourcesNameEnabled())
 
 	return output
@@ -154,10 +142,6 @@ func (switches *ControlSwitches) setAllFeaturesToInitialState() {
 	state = switches.configuration[enableHonorExistingResourcesKey]
 	state.setActiveToInitialState()
 	switches.configuration[enableHonorExistingResourcesKey] = state
-
-	state = switches.configuration[enableCustomizedInjectionKey]
-	state.setActiveToInitialState()
-	switches.configuration[enableCustomizedInjectionKey] = state
 }
 
 // setFeatureToState set given feature to the state defined in the map object
@@ -199,7 +183,6 @@ func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitches
 
 			switches.setFeatureToState(enableHugePageDownAPIKey, switchObj)
 			switches.setFeatureToState(enableHonorExistingResourcesKey, switchObj)
-			switches.setFeatureToState(enableCustomizedInjectionKey, switchObj)
 		} else {
 			glog.Warningf("Map does not contains [%s]", controlSwitchesMainKey)
 		}

--- a/pkg/controlswitches/controlswitches.go
+++ b/pkg/controlswitches/controlswitches.go
@@ -163,9 +163,8 @@ func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitches
 	var err error
 	if v, fileExists := controlSwitchesCm.Data[controlSwitchesFileKey]; fileExists {
 		var obj map[string]json.RawMessage
-		err = json.Unmarshal([]byte(v), &obj)
 
-		if err != nil {
+		if err = json.Unmarshal([]byte(v), &obj); err != nil {
 			glog.Warningf("Error during json unmarshal %v", err)
 			switches.setAllFeaturesToInitialState()
 			return
@@ -173,9 +172,8 @@ func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitches
 
 		if controlSwitches, mainExists := obj[controlSwitchesMainKey]; mainExists {
 			var switchObj map[string]bool
-			err = json.Unmarshal(controlSwitches, &switchObj)
 
-			if err != nil {
+			if err = json.Unmarshal(controlSwitches, &switchObj); err != nil {
 				glog.Warningf("Unable to unmarshal [%s] from configmap, err: %v", controlSwitchesMainKey, err)
 				switches.setAllFeaturesToInitialState()
 				return

--- a/pkg/controlswitches/controlswitches_suite_test.go
+++ b/pkg/controlswitches/controlswitches_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlswitches
+
+import (
+	"io/ioutil"
+	"log"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestWebhook(t *testing.T) {
+	log.SetOutput(ioutil.Discard)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controlswitches Suite")
+}

--- a/pkg/controlswitches/controlswitches_suite_test.go
+++ b/pkg/controlswitches/controlswitches_suite_test.go
@@ -15,8 +15,6 @@
 package controlswitches
 
 import (
-	"io/ioutil"
-	"log"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -24,7 +22,6 @@ import (
 )
 
 func TestWebhook(t *testing.T) {
-	log.SetOutput(ioutil.Discard)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controlswitches Suite")
 }

--- a/pkg/controlswitches/controlswitches_test.go
+++ b/pkg/controlswitches/controlswitches_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Verify controlswitches package", func() {
 	Describe("Common functions", func() {
 		Context("Display features", func() {
 			BeforeEach(func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createString(""))
 				structure.InitControlSwitches()
 			})
 
@@ -94,31 +94,27 @@ var _ = Describe("Verify controlswitches package", func() {
 			})
 
 			It("Feature set to false, other features set to true", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createBool(true), createString("something"))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createString("something"))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
 			})
 
 			It("Feature set to true, other features set to false", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createBool(false), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createString(""))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 		})
 	})
@@ -130,31 +126,27 @@ var _ = Describe("Verify controlswitches package", func() {
 			})
 
 			It("Feature set to false, other features set to true", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createBool(true), createString("something"))
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createString("something"))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
 			})
 
 			It("Feature set to true, other features set to false", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createBool(false), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createString(""))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 		})
 	})
@@ -166,33 +158,29 @@ var _ = Describe("Verify controlswitches package", func() {
 			})
 
 			It("Feature set to false, other features set to true", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createBool(true), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createString(""))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
 
 				Expect(structure.GetResourceNameKeys()).Should(Equal([]string{""}))
 			})
 
 			It("Feature set to true, other features set to false", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString("something"))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createString("something"))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 
 				Expect(structure.GetResourceNameKeys()).Should(Equal([]string{"something"}))
 			})
@@ -206,31 +194,27 @@ var _ = Describe("Verify controlswitches package", func() {
 			})
 
 			It("Feature set to false, other features set to true", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createBool(false), createString("something"))
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createString("something"))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Feature set to true, other features set to false", func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(true), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createString(""))
 				structure.InitControlSwitches()
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
 			})
 		})
 	})
@@ -238,7 +222,7 @@ var _ = Describe("Verify controlswitches package", func() {
 	Describe("Process Control Switches config map", func() {
 		Context("Map without [features]", func() {
 			BeforeEach(func() {
-				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString(""))
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createString(""))
 				structure.InitControlSwitches()
 			})
 
@@ -255,12 +239,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map without config.json key", func() {
@@ -272,12 +254,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, but without [features] inside", func() {
@@ -303,12 +283,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside, but features name are incorrect", func() {
@@ -339,20 +317,17 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside - but JSON is invalid", func() {
 				const value = `{
 							"features": {
 								"enableHugePageDownApi": false,
-								"enableHonorExistingResources": true,
-								"enableCustomizedInjection": false
+								"enableHonorExistingResources": true
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
 							"customInjection": {
@@ -374,20 +349,17 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside - all set to false", func() {
 				const value = `{
 							"features": {
 								"enableHugePageDownApi": false,
-								"enableHonorExistingResources": false,
-								"enableCustomizedInjection": false
+								"enableHonorExistingResources": false
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
 							"customInjection": {
@@ -409,12 +381,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			// set one by one, instead of all in one
@@ -422,8 +392,7 @@ var _ = Describe("Verify controlswitches package", func() {
 				const value = `{
 							"features": {
 								"enableHugePageDownApi": true,
-								"enableHonorExistingResources": "isThisAnError",
-								"enableCustomizedInjection": true
+								"enableHonorExistingResources": "isThisAnError"
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
 							"customInjection": {
@@ -445,20 +414,17 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside - all set to true", func() {
 				const value = `{
 							"features": {
 								"enableHugePageDownApi": true,
-								"enableHonorExistingResources": true,
-								"enableCustomizedInjection": true
+								"enableHonorExistingResources": true
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
 							"customInjection": {
@@ -480,20 +446,17 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside - mix with values true / false", func() {
 				const value = `{
 							"features": {
 								"enableHugePageDownApi": true,
-								"enableHonorExistingResources": false,
-								"enableCustomizedInjection": true
+								"enableHonorExistingResources": false
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
 							"customInjection": {
@@ -515,12 +478,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 
 			It("Map with correct key, with [features] inside - some features are missing", func() {
@@ -540,12 +501,10 @@ var _ = Describe("Verify controlswitches package", func() {
 
 				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
 				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
-				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
 				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
 
 				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
 				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
-				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
 			})
 		})
 	})

--- a/pkg/controlswitches/controlswitches_test.go
+++ b/pkg/controlswitches/controlswitches_test.go
@@ -1,0 +1,552 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controlswitches
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Helper functions
+
+func createBool(value bool) *bool {
+	return &value
+}
+
+func createString(value string) *string {
+	return &value
+}
+
+var _ = Describe("Verify controlswitches package", func() {
+	var structure *ControlSwitches
+
+	Describe("Common functions", func() {
+		Context("Display features", func() {
+			BeforeEach(func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString(""))
+				structure.InitControlSwitches()
+			})
+
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Setup structure", func() {
+				structure = SetupControlSwitchesFlags()
+				Expect(structure.IsValid()).Should(Equal(false))
+
+				structure.InitControlSwitches()
+				Expect(structure.IsValid()).Should(Equal(true))
+			})
+		})
+	})
+
+	Describe("Verify state structure", func() {
+		Context("Check", func() {
+			It("Set explicit active state", func() {
+				state := controlSwitchesStates{active: false, initial: false}
+
+				state.setActiveState(true)
+				Expect(state.active).Should(Equal(true))
+				Expect(state.initial).Should(Equal(false))
+
+				state.setActiveState(false)
+				Expect(state.active).Should(Equal(false))
+				Expect(state.initial).Should(Equal(false))
+			})
+
+			It("Set active to initial when initial is true", func() {
+				state := controlSwitchesStates{active: false, initial: true}
+
+				state.setActiveToInitialState()
+				Expect(state.active).Should(Equal(true))
+				Expect(state.initial).Should(Equal(true))
+			})
+
+			It("Set active to initial when initial is false", func() {
+				state := controlSwitchesStates{active: true, initial: false}
+
+				state.setActiveToInitialState()
+				Expect(state.active).Should(Equal(false))
+				Expect(state.initial).Should(Equal(false))
+			})
+		})
+	})
+
+	Describe("Hugepages downward API", func() {
+		Context("Feature configuration flags", func() {
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Feature set to false, other features set to true", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createBool(true), createString("something"))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
+			})
+
+			It("Feature set to true, other features set to false", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createBool(false), createString(""))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+		})
+	})
+
+	Describe("Honor existing resources", func() {
+		Context("Feature configuration flags", func() {
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Feature set to false, other features set to true", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(false), createBool(true), createString("something"))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
+			})
+
+			It("Feature set to true, other features set to false", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(true), createBool(false), createString(""))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+		})
+	})
+
+	Describe("Inject resource name keys ", func() {
+		Context("Feature configuration flags", func() {
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Feature set to false, other features set to true", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createBool(true), createString(""))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
+
+				Expect(structure.GetResourceNameKeys()).Should(Equal([]string{""}))
+			})
+
+			It("Feature set to true, other features set to false", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString("something"))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+
+				Expect(structure.GetResourceNameKeys()).Should(Equal([]string{"something"}))
+			})
+		})
+	})
+
+	Describe("User defined injections", func() {
+		Context("Feature configuration flags", func() {
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Feature set to false, other features set to true", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(true), createBool(true), createBool(false), createString("something"))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(true))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(true))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Feature set to true, other features set to false", func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(true), createString(""))
+				structure.InitControlSwitches()
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(true))
+			})
+		})
+	})
+
+	Describe("Process Control Switches config map", func() {
+		Context("Map without [features]", func() {
+			BeforeEach(func() {
+				structure = SetupControlSwitchesUnitTests(createBool(false), createBool(false), createBool(false), createString(""))
+				structure.InitControlSwitches()
+			})
+
+			AfterEach(func() {
+				structure = nil
+			})
+
+			It("Missing key", func() {
+				cm := corev1.ConfigMap{
+					Data: map[string]string{},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map without config.json key", func() {
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"nri-inject-annotation": "true"},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, but without [features] inside", func() {
+				const value = `{
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside, but features name are incorrect", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDown": false,
+								"enableHonorExisting": true,
+								"enableCustomizedInje": false,
+								"enableResourceNa": false
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside - but JSON is invalid", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": false,
+								"enableHonorExistingResources": true,
+								"enableCustomizedInjection": false
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations"
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside - all set to false", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": false,
+								"enableHonorExistingResources": false,
+								"enableCustomizedInjection": false
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			// set one by one, instead of all in one
+			It("Map with correct key, with [features] inside - value of feature set to string instead of bool", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": true,
+								"enableHonorExistingResources": "isThisAnError",
+								"enableCustomizedInjection": true
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(false))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside - all set to true", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": true,
+								"enableHonorExistingResources": true,
+								"enableCustomizedInjection": true
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(true))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside - mix with values true / false", func() {
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": true,
+								"enableHonorExistingResources": false,
+								"enableCustomizedInjection": true
+							},
+							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
+							"customInjection": {
+								"network-resource-injector-pod-annotation": {
+									"op": "add",
+								 	"path": "/metadata/annotations",
+								  	"value": {
+										  "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+									}
+								}
+							}
+						}
+						`
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(true))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+
+			It("Map with correct key, with [features] inside - some features are missing", func() {
+				// create map that does not have all features defined, expected to be removed
+				const value = `{
+							"features": {
+								"enableHugePageDownApi": true
+							}
+						}
+						`
+
+				cm := corev1.ConfigMap{
+					Data: map[string]string{"config.json": value},
+				}
+
+				structure.ProcessControlSwitchesConfigMap(&cm)
+
+				Expect(structure.IsHugePagedownAPIEnabled()).Should(Equal(true))
+				Expect(structure.IsHonorExistingResourcesEnabled()).Should(Equal(false))
+				Expect(structure.IsCustomizedInjectionsEnabled()).Should(Equal(false))
+				Expect(structure.IsResourcesNameEnabled()).Should(Equal(false))
+
+				Expect(structure.configuration[enableHugePageDownAPIKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableHonorExistingResourcesKey].initial).Should(Equal(false))
+				Expect(structure.configuration[enableCustomizedInjectionKey].initial).Should(Equal(false))
+			})
+		})
+	})
+})

--- a/pkg/controlswitches/controlswitchesaccessors.go
+++ b/pkg/controlswitches/controlswitchesaccessors.go
@@ -19,13 +19,12 @@
 
 package controlswitches
 
-func SetupControlSwitchesUnitTests(downAPI, honor, injection *bool, name *string) *ControlSwitches {
+func SetupControlSwitchesUnitTests(downAPI, honor *bool, name *string) *ControlSwitches {
 	var initFlags ControlSwitches
 
 	initFlags.injectHugepageDownAPI = downAPI
 	initFlags.resourceNameKeysFlag = name
 	initFlags.resourcesHonorFlag = honor
-	initFlags.userInjectionFlag = injection
 
 	return &initFlags
 }

--- a/pkg/controlswitches/controlswitchesaccessors.go
+++ b/pkg/controlswitches/controlswitchesaccessors.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unittests
+
+// This file should be only include in build system during unit tests execution.
+// Special method allows to setup structure with values needed by test.
+
+package controlswitches
+
+func SetupControlSwitchesUnitTests(downAPI, honor, injection *bool, name *string) *ControlSwitches {
+	var initFlags ControlSwitches
+
+	initFlags.injectHugepageDownAPI = downAPI
+	initFlags.resourceNameKeysFlag = name
+	initFlags.resourcesHonorFlag = honor
+	initFlags.userInjectionFlag = injection
+
+	return &initFlags
+}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -685,10 +685,6 @@ func getResourceList(resourceRequests map[string]int64) *corev1.ResourceList {
 func createCustomizedPatch(pod corev1.Pod) ([]jsonPatchOperation, error) {
 	var userDefinedPatch []jsonPatchOperation
 
-	if !controlSwitches.IsCustomizedInjectionsEnabled() {
-		return userDefinedPatch, nil
-	}
-
 	// lock for reading
 	userDefinedInjects.Lock()
 	defer userDefinedInjects.Unlock()
@@ -976,10 +972,6 @@ func SetupInClusterClient() kubernetes.Interface {
 
 // SetCustomizedInjections sets additional injections to be applied in Pod spec
 func SetCustomizedInjections(injections *corev1.ConfigMap) {
-	if !controlSwitches.IsCustomizedInjectionsEnabled() {
-		return
-	}
-
 	// lock for writing
 	userDefinedInjects.Lock()
 	defer userDefinedInjects.Unlock()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,5 +21,5 @@ root="$(dirname "$0")/.."
 time=$(date +'%Y-%m-%d_%H-%M-%S')
 filePath="/tmp/go-cover.$time.tmp"
 echo "Coverage profile file path: $filePath"
-go test -coverprofile="$filePath" "./${root}/pkg/..."
+go test --tags=unittests -coverprofile="$filePath" "./${root}/pkg/..."
 go tool cover -html="$filePath"


### PR DESCRIPTION
The aim of this pull request is to solve problem describe within issue https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/61 

This pull request brings first part of new configMap support - so the handing of feature state in runtime. With new configMap described wider in **readme** it is possible to change initial feature state without need to NRI recreation.

The implementation is done within controlswitches package. In result, some parts of code were moved from webhook.go file.