### PR TITLE
E2E test with focus on control switches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,8 @@
 name: e2e
-on: [push, pull_request]
+on: [pull_request]
 jobs:
-  e2e-test:
-    name: E2E test
+  e2e-test-cloud:
+    name: E2E test cloud (GitHub VM)
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go version
@@ -17,4 +17,27 @@ jobs:
         run: source scripts/e2e_get_tools.sh && ./scripts/e2e_setup_cluster.sh
 
       - name: Execute E2E tests
-        run: go test -v ./test/e2e/...
+        run: go test -v -timeout 60m ./test/e2e/...
+
+  e2e-test-self-hosted:
+    name: E2E test self-hosted
+    environment: nri-team
+    runs-on: [self-hosted, Linux, hugepages]
+    steps:
+      - name: Set up Go version
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get tools, setup KinD cluster test environment
+        run: source scripts/e2e_get_tools.sh && ./scripts/e2e_setup_cluster.sh
+
+      - name: Execute E2E tests
+        run: go test -timeout 60m ./test/e2e/...
+
+      - name: Tear down KinD cluster
+        if: always()
+        run: ./scripts/e2e_teardown_cluster.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,25 +19,26 @@ jobs:
       - name: Execute E2E tests
         run: go test -v -timeout 60m ./test/e2e/...
 
-  e2e-test-self-hosted:
-    name: E2E test self-hosted
-    environment: nri-team
-    runs-on: [self-hosted, Linux, hugepages]
-    steps:
-      - name: Set up Go version
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.13
+# Disable for now because there is no dedicated server on which those tests can be run by GitHub.
+  # e2e-test-self-hosted:
+  #   name: E2E test self-hosted
+  #   environment: nri-team
+  #   runs-on: [self-hosted, Linux, hugepages]
+  #   steps:
+  #     - name: Set up Go version
+  #       uses: actions/setup-go@v1
+  #       with:
+  #         go-version: 1.13
 
-      - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+  #     - name: Checkout code into the Go module directory
+  #       uses: actions/checkout@v2
 
-      - name: Get tools, setup KinD cluster test environment
-        run: source scripts/e2e_get_tools.sh && ./scripts/e2e_setup_cluster.sh
+  #     - name: Get tools, setup KinD cluster test environment
+  #       run: source scripts/e2e_get_tools.sh && ./scripts/e2e_setup_cluster.sh
 
-      - name: Execute E2E tests
-        run: go test -timeout 60m ./test/e2e/...
+  #     - name: Execute E2E tests
+  #       run: go test -timeout 60m ./test/e2e/...
 
-      - name: Tear down KinD cluster
-        if: always()
-        run: ./scripts/e2e_teardown_cluster.sh
+  #     - name: Tear down KinD cluster
+  #       if: always()
+  #       run: ./scripts/e2e_teardown_cluster.sh

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ vendor :
 
 e2e:
 	source scripts/e2e_get_tools.sh && scripts/e2e_setup_cluster.sh
-	go test ./test/e2e/...
+	go test -timeout 40m -v ./test/e2e/...
 
 e2e-clean:
 	source scripts/e2e_get_tools.sh && scripts/e2e_teardown_cluster.sh

--- a/deployments/server_huge.yaml
+++ b/deployments/server_huge.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: network-resources-injector
+  name: network-resources-injector
+  namespace: kube-system
+spec:
+  serviceAccount: network-resources-injector-sa
+  containers:
+  - name: webhook-server
+    image: network-resources-injector:latest
+    imagePullPolicy: IfNotPresent
+    command:
+    - webhook
+    args:
+    - -bind-address=0.0.0.0
+    - -port=8443
+    - -tls-private-key-file=/etc/tls/tls.key
+    - -tls-cert-file=/etc/tls/tls.crt
+    - -logtostderr
+    - -injectHugepageDownApi
+    securityContext:
+      runAsUser: 10000
+      runAsGroup: 10000
+      capabilities:
+        drop:
+          - ALL
+        add: ["NET_BIND_SERVICE"]
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+    volumeMounts:
+    - mountPath: /etc/tls
+      name: tls
+    resources:
+      requests:
+        memory: "50Mi"
+        cpu: "250m"
+      limits:
+        memory: "200Mi"
+        cpu: "500m"
+  initContainers:
+  - name: installer
+    image: network-resources-injector:latest
+    imagePullPolicy: IfNotPresent
+    command:
+    - installer
+    args:
+    - -name=network-resources-injector
+    - -namespace=kube-system
+    - -alsologtostderr
+    securityContext:
+      runAsUser: 10000
+      runAsGroup: 10000
+    volumeMounts:
+    - name: tls
+      mountPath: /etc/tls
+  volumes:
+  - name: tls
+    emptyDir: {}
+
+# For third-party certificate, use secret resource
+# instead of self-generated one from installer as below:
+#
+# 1) Remove initContainers from Pod spec.
+# 2) Replace `emptyDir: {}` with below config
+#
+#   secret:
+#     secretName: network-resources-injector-secret

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/scripts/e2e_get_tools.sh
+++ b/scripts/e2e_get_tools.sh
@@ -13,7 +13,7 @@ if [ ! -d "${root}/bin" ]; then
 fi
 
 echo "retrieving kind"
-curl --max-time 10 --retry 10 --retry-delay 5 --retry-max-time 60 -Lo "${root}/bin/kind" "${KIND_BINARY_URL}"
+curl --max-time 20 --retry 10 --retry-delay 5 --retry-max-time 300 -Lo "${root}/bin/kind" "${KIND_BINARY_URL}"
 chmod +x "${root}/bin/kind"
 
 echo "retrieving kubectl"

--- a/test/e2e/control_switches_test.go
+++ b/test/e2e/control_switches_test.go
@@ -1,0 +1,221 @@
+package e2e
+
+//a subset of tests require Hugepages enabled on the test node
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/test/util"
+
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+func hugepageOrSkip() {
+	available, err := util.IsMinHugepagesAvailable(cs.CoreV1Interface, minHugepages1Gi, minHugepages2Mi)
+	Expect(err).To(BeNil())
+	if !available {
+		Skip(fmt.Sprintf("minimum hugepages of %d Gi and %d Mi not found in any k8 worker nodes.",
+			minHugepages1Gi, minHugepages2Mi))
+	}
+}
+
+var _ = Describe("Verify configuration set by control switches", func() {
+	var pod *corev1.Pod
+	var configMap, userConfigMap *corev1.ConfigMap
+	var nad *cniv1.NetworkAttachmentDefinition
+	var err error
+
+	BeforeEach(hugepageOrSkip)
+
+	Context("Incorrect nri-control-switches ConfigMap", func() {
+		BeforeEach(func() {
+			userConfigMap = util.GetConfigMap("nri-user-defined-injections", "kube-system")
+			userConfigMap = util.AddData(userConfigMap,
+				"customInjection",
+				"{\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {\"top-secret\": \"password\"}}")
+			err = util.ApplyConfigMap(cs.CoreV1Interface, userConfigMap, timeout)
+			Expect(err).Should(BeNil())
+
+			nad = util.GetResourceSelectorOnly(testNetworkName, *testNs, testNetworkResName)
+			err = util.ApplyNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, nad, timeout)
+			Expect(err).Should(BeNil())
+		})
+
+		AfterEach(func() {
+			_ = util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeleteNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, testNetworkName, nad, timeout)
+
+			if nil != userConfigMap {
+				_ = util.DeleteConfigMap(cs.CoreV1Interface, userConfigMap, timeout)
+				userConfigMap = nil
+			}
+
+			if nil != configMap {
+				_ = util.DeleteConfigMap(cs.CoreV1Interface, configMap, timeout)
+				configMap = nil
+			}
+		})
+
+		DescribeTable("verify if ConfigMap was accepted", func(configValue string) {
+			configMap = util.GetConfigMap("nri-control-switches", "kube-system")
+			configMap = util.AddData(configMap, "config.json", configValue)
+			err = util.ApplyConfigMap(cs.CoreV1Interface, configMap, timeout)
+			Expect(err).Should(BeNil())
+
+			// wait for configmap to be consumed by NRI
+			time.Sleep(60 * time.Second)
+
+			pod = util.GetOneNetwork(testNetworkName, *testNs, defaultPodName)
+			pod = util.AddMetadataLabel(pod, "customInjection", "true")
+			err = util.CreateRunningPod(cs.CoreV1Interface, pod, timeout, interval)
+			Expect(err).Should(BeNil())
+			Expect(pod.Name).ShouldNot(BeNil())
+
+			pod, err = util.UpdatePodInfo(cs.CoreV1Interface, pod, timeout)
+			Expect(err).Should(BeNil())
+
+			Expect(pod.Annotations["top-secret"]).Should(ContainSubstring("password"))
+		},
+			Entry("without features definition, correct namespace", ""),
+			Entry("all features disabled, correct namespace", `{
+				"features": {
+					"enableHugePageDownApi": false,
+					"enableHonorExistingResources": false,
+					"enableCustomizedInjection": false,
+					"enableResourceName": false
+				}
+			}
+			`),
+			Entry("unknown features or misspelled, correct namespace", `{
+				"features": {
+					"someSuperFeature": false,
+					"resourceName": false
+				}
+			}
+			`),
+		)
+	})
+})
+
+var _ = Describe("Verify configuration set by control switches", func() {
+	var pod *corev1.Pod
+	var configMap *corev1.ConfigMap
+	var nad *cniv1.NetworkAttachmentDefinition
+	var err error
+	var stdoutString, stderrString string
+
+	BeforeEach(hugepageOrSkip)
+
+	Context("Check downward API setting with huge pages", func() {
+		BeforeEach(func() {
+			stdoutString = ""
+			stderrString = ""
+		})
+
+		AfterEach(func() {
+			_ = util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeleteNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, testNetworkName, nad, timeout)
+
+			if nil != configMap {
+				_ = util.DeleteConfigMap(cs.CoreV1Interface, configMap, timeout)
+				configMap = nil
+			}
+		})
+
+		It("POD with annotation about resourceName, hugepages1Gi limit and memory size are defined and are equal", func() {
+			nad = util.GetResourceSelectorOnly(testNetworkName, *testNs, testNetworkResName)
+			err = util.ApplyNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, nad, timeout)
+			Expect(err).Should(BeNil())
+
+			pod = util.GetOneNetwork(testNetworkName, *testNs, defaultPodName)
+			pod = util.AddToPodDefinitionHugePages1Gi(pod, 2, 2, 0)
+			pod = util.AddToPodDefinitionMemory(pod, 2, 2, 0)
+
+			err = util.CreateRunningPod(cs.CoreV1Interface, pod, timeout, interval)
+			Expect(err).Should(BeNil())
+			Expect(pod.Name).ShouldNot(BeNil())
+
+			// Check new environment variable
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "printenv")
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).Should(ContainSubstring("HOSTNAME=" + pod.Name))
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "ls /etc/podnetinfo")
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).Should(ContainSubstring("hugepages_1G_limit_" + pod1stContainerName))
+			Expect(stdoutString).Should(ContainSubstring("hugepages_1G_request_" + pod1stContainerName))
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "cat /etc/podnetinfo/hugepages_1G_limit_"+pod1stContainerName)
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).ShouldNot(Equal(""))
+			size, err := strconv.ParseInt(stdoutString, 10, 32)
+			Expect(err).Should(BeNil())
+			Expect(size).Should(Equal(int64(2048)))
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "cat /etc/podnetinfo/hugepages_1G_request_"+pod1stContainerName)
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).ShouldNot(Equal(""))
+			size, err = strconv.ParseInt(stdoutString, 10, 32)
+			Expect(err).Should(BeNil())
+			Expect(size).Should(Equal(int64(2048)))
+
+			err = util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			Expect(err).Should(BeNil())
+
+			const disabledState = `{
+				"features": {
+					"enableHugePageDownApi": false,
+					"enableHonorExistingResources": false,
+					"enableCustomizedInjection": false,
+					"enableResourceName": false
+				}
+			}
+			`
+
+			configMap = util.GetConfigMap("nri-control-switches", "kube-system")
+			configMap = util.AddData(configMap, "config.json", disabledState)
+			err = util.ApplyConfigMap(cs.CoreV1Interface, configMap, timeout)
+			Expect(err).Should(BeNil())
+
+			// wait for configmap to be consumed by NRI
+			time.Sleep(60 * time.Second)
+
+			pod = util.GetOneNetwork(testNetworkName, *testNs, defaultPodName)
+			pod = util.AddToPodDefinitionHugePages1Gi(pod, 2, 2, 0)
+			pod = util.AddToPodDefinitionMemory(pod, 2, 2, 0)
+
+			err = util.CreateRunningPod(cs.CoreV1Interface, pod, timeout, interval)
+			Expect(err).Should(BeNil())
+			Expect(pod.Name).ShouldNot(BeNil())
+
+			// Check new environment variable
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "printenv")
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).Should(ContainSubstring("HOSTNAME=" + pod.Name))
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "ls /etc/podnetinfo")
+			Expect(err).Should(BeNil())
+			Expect(stderrString).Should(Equal(""))
+			Expect(stdoutString).ShouldNot(ContainSubstring("hugepages_1G_limit_" + pod1stContainerName))
+			Expect(stdoutString).ShouldNot(ContainSubstring("hugepages_1G_request_" + pod1stContainerName))
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "cat /etc/podnetinfo/hugepages_1G_limit_"+pod1stContainerName)
+			Expect(err).ShouldNot(BeNil())
+
+			stdoutString, stderrString, err = util.ExecuteCommand(cs.CoreV1Interface, kubeConfig, pod.Name, *testNs, pod1stContainerName, "cat /etc/podnetinfo/hugepages_1G_request_"+pod1stContainerName)
+			Expect(err).ShouldNot(BeNil())
+		})
+
+	})
+})

--- a/test/e2e/e2e_tests_suite_test.go
+++ b/test/e2e/e2e_tests_suite_test.go
@@ -6,19 +6,24 @@ import (
 	"testing"
 	"time"
 
+	networkCoreClient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
 )
 
-
 const (
-	testNetworkName    = "foo-network"
-	testNetworkResName = "example.com/foo"
-	interval           = time.Second * 10
-	timeout            = time.Second * 30
+	defaultPodName      = "nri-e2e-test"
+	testNetworkName     = "foo-network"
+	pod1stContainerName = "test"
+	testNetworkResName  = "example.com/foo"
+	interval            = time.Second * 10
+	timeout             = time.Second * 30
+	minHugepages1Gi     = 2
+	minHugepages2Mi     = 1024
 )
 
 var (
@@ -26,13 +31,19 @@ var (
 	kubeConfigPath *string
 	testNs         *string
 	cs             *ClientSet
+	networkClient  *NetworkClientSet
+	kubeConfig     *restclient.Config
 )
 
 type ClientSet struct {
 	coreclient.CoreV1Interface
 }
 
-func init()  {
+type NetworkClientSet struct {
+	networkCoreClient.K8sCniCncfIoV1Interface
+}
+
+func init() {
 	if home := homedir.HomeDir(); home != "" {
 		kubeConfigPath = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "path to your kubeconfig file")
 	} else {
@@ -51,8 +62,13 @@ var _ = BeforeSuite(func(done Done) {
 	cfg, err := clientcmd.BuildConfigFromFlags(*master, *kubeConfigPath)
 	Expect(err).Should(BeNil())
 
+	kubeConfig = cfg
+
 	cs = &ClientSet{}
 	cs.CoreV1Interface = coreclient.NewForConfigOrDie(cfg)
+
+	networkClient = &NetworkClientSet{}
+	networkClient.K8sCniCncfIoV1Interface = networkCoreClient.NewForConfigOrDie(cfg)
 
 	close(done)
 }, 60)

--- a/test/e2e/httpserver_test.go
+++ b/test/e2e/httpserver_test.go
@@ -1,19 +1,25 @@
 package e2e
 
 import (
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/k8snetworkplumbingwg/network-resources-injector/test/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Network injection testing", func(){
+var _ = Describe("Network injection testing", func() {
 	var pod *corev1.Pod
 	var err error
+	var nad *cniv1.NetworkAttachmentDefinition
 
 	Context("one network request", func() {
 		BeforeEach(func() {
-			pod = util.GetOneNetwork(testNetworkName, *testNs)
+			nad = util.GetResourceSelectorOnly(testNetworkName, *testNs, testNetworkResName)
+			err = util.ApplyNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, nad, timeout)
+			Expect(err).Should(BeNil())
+
+			pod = util.GetOneNetwork(testNetworkName, *testNs, defaultPodName)
 			err = util.CreateRunningPod(cs.CoreV1Interface, pod, timeout, interval)
 			Expect(err).Should(BeNil())
 			Expect(pod.Name).ShouldNot(BeNil())
@@ -22,7 +28,8 @@ var _ = Describe("Network injection testing", func(){
 		})
 
 		AfterEach(func() {
-			util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeleteNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, testNetworkName, nad, timeout)
 		})
 
 		It("should have one limit injected", func() {
@@ -36,16 +43,22 @@ var _ = Describe("Network injection testing", func(){
 			Expect(limNo.String()).Should(Equal("1"))
 		})
 	})
+
 	Context("two network requests", func() {
 		BeforeEach(func() {
-			pod = util.GetMultiNetworks([]string{testNetworkName, testNetworkName}, *testNs)
+			nad = util.GetResourceSelectorOnly(testNetworkName, *testNs, testNetworkResName)
+			err = util.ApplyNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, nad, timeout)
+			Expect(err).Should(BeNil())
+
+			pod = util.GetMultiNetworks([]string{testNetworkName, testNetworkName}, *testNs, defaultPodName)
 			err = util.CreateRunningPod(cs.CoreV1Interface, pod, timeout, interval)
 			Expect(err).Should(BeNil())
 			pod, err = util.UpdatePodInfo(cs.CoreV1Interface, pod, timeout)
 		})
 
 		AfterEach(func() {
-			util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeletePod(cs.CoreV1Interface, pod, timeout)
+			_ = util.DeleteNetworkAttachmentDefinition(networkClient.K8sCniCncfIoV1Interface, testNetworkName, nad, timeout)
 		})
 
 		It("should have two limits injected", func() {

--- a/test/util/configmap.go
+++ b/test/util/configmap.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func GetConfigMap(confgiMapName, namespace string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      confgiMapName,
+			Namespace: namespace,
+		},
+	}
+}
+
+func AddData(configMap *corev1.ConfigMap, dataKey, dataValue string) *corev1.ConfigMap {
+	if nil == configMap.Data {
+		configMap.Data = make(map[string]string)
+	}
+
+	configMap.Data[dataKey] = dataValue
+
+	return configMap
+}
+
+func ApplyConfigMap(ci coreclient.CoreV1Interface, configMap *corev1.ConfigMap, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	defer cancel()
+	_, err := ci.ConfigMaps(configMap.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteConfigMap(ci coreclient.CoreV1Interface, configMap *corev1.ConfigMap, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := ci.ConfigMaps(configMap.Namespace).Delete(ctx, configMap.Name, metav1.DeleteOptions{})
+	return err
+}

--- a/test/util/features.go
+++ b/test/util/features.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+const (
+	hugepagesResourceName2Mi = "hugepages-2Mi"
+	hugepagesResouceName1Gi  = "hugepages-1Gi"
+)
+
+//IsMinHugepagesAvailable checks if a min Gi/Mi hugepage number is available on any nodes
+func IsMinHugepagesAvailable(ci coreclient.CoreV1Interface, minGi, minMi int) (bool, error) {
+	hugepages := map[string]int{hugepagesResouceName1Gi: minGi, hugepagesResourceName2Mi: minMi}
+	list, err := ci.Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+
+	if minGi == 0 && minMi == 0 {
+		return false, fmt.Errorf("IsHugepagesAvailable(): define at least greater than zero hugepages")
+	}
+
+	if len(list.Items) == 0 {
+		return false, fmt.Errorf("IsHugepagesAvailable(): no nodes available")
+	}
+
+	foundOnce := map[string]bool{hugepagesResouceName1Gi: false, hugepagesResourceName2Mi: false}
+
+	for _, node := range list.Items {
+		for resource, minHugepages := range hugepages {
+			if minHugepages == 0 {
+				foundOnce[resource] = true
+				continue
+			}
+			capacity, ok := node.Status.Capacity[v1.ResourceName(resource)]
+			if !ok {
+				return false, fmt.Errorf("IsHugepagesAvailable(): cannot find hugepage resource %s via K8 API", resource)
+			}
+			size, ok := capacity.AsInt64()
+			if !ok {
+				return false, fmt.Errorf("IsHugepagesAvailable(): failed to convert hugepage capacity")
+			}
+			if int64(minHugepages) <= size {
+				foundOnce[resource] = true
+			}
+		}
+	}
+	return foundOnce[hugepagesResourceName2Mi] && foundOnce[hugepagesResouceName1Gi], nil
+}

--- a/test/util/images.go
+++ b/test/util/images.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	registry string
+	registry  string
 	testImage string
 )
 
@@ -21,7 +21,7 @@ func init() {
 	}
 }
 
-//GetPodTestImage returns image to be used during testing
+// GetPodTestImage returns image to be used during testing
 func GetPodTestImage() string {
 	return fmt.Sprintf("%s/%s", registry, testImage)
 }

--- a/test/util/networkattachmentdefinition.go
+++ b/test/util/networkattachmentdefinition.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	cniv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	networkCoreClient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetWithoutAnnotations(ns string, networkName string) *cniv1.NetworkAttachmentDefinition {
+	nad := GetNetworkAttachmentDefinition(ns, networkName)
+
+	return nad
+}
+
+func GetResourceSelectorOnly(ns string, networkName string, resourceName string) *cniv1.NetworkAttachmentDefinition {
+	nad := GetNetworkAttachmentDefinition(ns, networkName)
+	nad.Annotations = map[string]string{"k8s.v1.cni.cncf.io/resourceName": resourceName}
+
+	return nad
+}
+
+func GetNodeSelectorOnly(ns string, networkName string, nodeName string) *cniv1.NetworkAttachmentDefinition {
+	nad := GetNetworkAttachmentDefinition(ns, networkName)
+	nad.Annotations = map[string]string{"k8s.v1.cni.cncf.io/nodeSelector": nodeName}
+
+	return nad
+}
+
+func GetResourceAndNodeSelector(ns string, networkName string, nodeName string) *cniv1.NetworkAttachmentDefinition {
+	nad := GetNetworkAttachmentDefinition(ns, networkName)
+	nad.Annotations = map[string]string{
+		"k8s.v1.cni.cncf.io/nodeSelector": nodeName,
+		"k8s.v1.cni.cncf.io/resourceName": "example.com/foo",
+	}
+
+	return nad
+}
+
+func GetNetworkAttachmentDefinition(networkName string, ns string) *cniv1.NetworkAttachmentDefinition {
+	return &cniv1.NetworkAttachmentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      networkName,
+			Namespace: ns,
+		},
+		Spec: cniv1.NetworkAttachmentDefinitionSpec{
+			Config: GetNetworkSpecConfig(networkName),
+		},
+	}
+}
+
+// {
+// 				"cniVersion": "0.3.0",
+// 				"name":       networkName,
+// 				"type":       "loopback",
+// 			},
+func GetNetworkSpecConfig(networkName string) string {
+	config := "{\"cniVersion\": \"0.3.0\", \"name\": \"" + networkName + "\", \"type\":\"loopback\"}"
+	return config
+}
+
+func ApplyNetworkAttachmentDefinition(ci networkCoreClient.K8sCniCncfIoV1Interface, nad *cniv1.NetworkAttachmentDefinition, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	defer cancel()
+	_, err := ci.NetworkAttachmentDefinitions(nad.Namespace).Create(ctx, nad, metav1.CreateOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteNetworkAttachmentDefinition(ci networkCoreClient.K8sCniCncfIoV1Interface, testNetworkName string, nad *cniv1.NetworkAttachmentDefinition, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
+	defer cancel()
+	err := ci.NetworkAttachmentDefinitions(nad.Namespace).Delete(ctx, testNetworkName, metav1.DeleteOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/util/pod.go
+++ b/test/util/pod.go
@@ -1,18 +1,23 @@
 package util
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 )
 
-//CreateRunningPod create a pod and wait until it is running
+// CreateRunningPod create a pod and wait until it is running
 func CreateRunningPod(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout, interval time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -27,7 +32,7 @@ func CreateRunningPod(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout, i
 	return nil
 }
 
-//DeletePod will delete a pod
+// DeletePod will delete a pod
 func DeletePod(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout time.Duration) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -35,7 +40,7 @@ func DeletePod(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout time.Dura
 	return err
 }
 
-//UpdatePodInfo will get the current pod state and return it
+// UpdatePodInfo will get the current pod state and return it
 func UpdatePodInfo(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout time.Duration) (*corev1.Pod, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -46,20 +51,20 @@ func UpdatePodInfo(ci coreclient.CoreV1Interface, pod *corev1.Pod, timeout time.
 	return pod, nil
 }
 
-//GetPodDefinition will return a test pod
-func GetPodDefinition(ns string) *corev1.Pod {
+// GetPodDefinition will return a test pod
+func GetPodDefinition(ns string, podName string) *corev1.Pod {
 	var graceTime int64 = 0
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "nri-e2e-test",
-			Namespace:    ns,
+			Name:      podName,
+			Namespace: ns,
 		},
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: &graceTime,
 			Containers: []corev1.Container{
 				{
-					Name: "test",
-					Image: GetPodTestImage(),
+					Name:    "test",
+					Image:   GetPodTestImage(),
 					Command: []string{"/bin/sh", "-c", "sleep INF"},
 				},
 			},
@@ -67,22 +72,67 @@ func GetPodDefinition(ns string) *corev1.Pod {
 	}
 }
 
-//GetOneNetwork add one network to pod
-func GetOneNetwork(nad, ns string) *corev1.Pod {
-	pod := GetPodDefinition(ns)
+// AddMetadataLabel adds label to the POD metadata section
+// :param labelName - key in map, label name
+// :param labelContent - value, label content
+func AddMetadataLabel(pod *corev1.Pod, labelName, labelContent string) *corev1.Pod {
+	if nil == pod.ObjectMeta.Labels {
+		pod.ObjectMeta.Labels = make(map[string]string)
+	}
+
+	pod.ObjectMeta.Labels[labelName] = labelContent
+
+	return pod
+}
+
+// AddToPodDefinitionHugePages1Gi adds Hugepages 1Gi limits and requirements to the POD spec.
+func AddToPodDefinitionHugePages1Gi(pod *corev1.Pod, amountLimit, amountRequest, containerNumber int64) *corev1.Pod {
+	if nil == pod.Spec.Containers[containerNumber].Resources.Limits {
+		pod.Spec.Containers[containerNumber].Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	if nil == pod.Spec.Containers[containerNumber].Resources.Requests {
+		pod.Spec.Containers[containerNumber].Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	pod.Spec.Containers[containerNumber].Resources.Limits["hugepages-1Gi"] = *resource.NewQuantity(amountLimit*1024*1024*1024, resource.BinarySI)
+	pod.Spec.Containers[containerNumber].Resources.Requests["hugepages-1Gi"] = *resource.NewQuantity(amountRequest*1024*1024*1024, resource.BinarySI)
+
+	return pod
+}
+
+// AddToPodDefinitionMemory adds Memory constraints to the POD spec.
+func AddToPodDefinitionMemory(pod *corev1.Pod, amountLimit, amountRequest, containerNumber int64) *corev1.Pod {
+	if nil == pod.Spec.Containers[containerNumber].Resources.Limits {
+		pod.Spec.Containers[containerNumber].Resources.Limits = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	if nil == pod.Spec.Containers[containerNumber].Resources.Requests {
+		pod.Spec.Containers[containerNumber].Resources.Requests = make(map[corev1.ResourceName]resource.Quantity)
+	}
+
+	pod.Spec.Containers[containerNumber].Resources.Limits["memory"] = *resource.NewQuantity(amountLimit*1024*1024*1024, resource.BinarySI)
+	pod.Spec.Containers[containerNumber].Resources.Requests["memory"] = *resource.NewQuantity(amountRequest*1024*1024*1024, resource.BinarySI)
+
+	return pod
+}
+
+// GetOneNetwork add one network to pod
+func GetOneNetwork(nad, ns, podName string) *corev1.Pod {
+	pod := GetPodDefinition(ns, podName)
 	pod.Annotations = map[string]string{"k8s.v1.cni.cncf.io/networks": nad}
 	return pod
 }
 
-//GetMultiNetworks adds a network to annotation
-func GetMultiNetworks(nad []string, ns string) *corev1.Pod {
-	pod := GetPodDefinition(ns)
+// GetMultiNetworks adds a network to annotation
+func GetMultiNetworks(nad []string, ns, podName string) *corev1.Pod {
+	pod := GetPodDefinition(ns, podName)
 	pod.Annotations = map[string]string{"k8s.v1.cni.cncf.io/networks": strings.Join(nad, ",")}
 	return pod
 }
 
-//WaitForPodStateRunning waits for pod to enter running state
-func WaitForPodStateRunning(core coreclient.CoreV1Interface , podName, ns string, timeout, interval time.Duration) error {
+// WaitForPodStateRunning waits for pod to enter running state
+func WaitForPodStateRunning(core coreclient.CoreV1Interface, podName, ns string, timeout, interval time.Duration) error {
 	time.Sleep(30 * time.Second)
 	return wait.PollImmediate(interval, timeout, func() (done bool, err error) {
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -99,4 +149,47 @@ func WaitForPodStateRunning(core coreclient.CoreV1Interface , podName, ns string
 		}
 		return false, nil
 	})
+}
+
+// ExecuteCommand execute command on the POD
+// :param core - core V1 Interface
+// :param config - configuration used to establish REST connection with K8s node
+// :param podName - POD name on which command has to be executed
+// :param ns - namespace in which POD exists
+// :param containerName - container name on which command should be executed
+// :param command - command to be executed on POD
+// :return string output of the command (stdout)
+// 	       string output of the command (stderr)
+//         error Error object or when everthing is correct nil
+func ExecuteCommand(core coreclient.CoreV1Interface, config *restclient.Config, podName, ns, containerName, command string) (string, string, error) {
+	shellCommand := []string{"/bin/sh", "-c", command}
+	request := core.RESTClient().Post().Resource("pods").Name(podName).Namespace(ns).SubResource("exec")
+	options := &corev1.PodExecOptions{
+		Command:   shellCommand,
+		Container: containerName,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}
+
+	request.VersionedParams(options, scheme.ParameterCodec)
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", request.URL())
+	if nil != err {
+		return "", "", err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+
+	if nil != err {
+		return "", "", err
+	}
+
+	return stdout.String(), stderr.String(), nil
 }


### PR DESCRIPTION
This pull request provides E2E tests that are focusing on verification how control switches configmap works in real cluster.

Test file was implemented by @MichalGuzieniuk (michalx.guzieniuk@intel.com)
Co-authored-by: @martinkennelly Martin Kennelly (martin.kennelly@intel.com) who mainly develop the utils.

This change contains some code that is visible within other PR https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/98

Hugepages test is optional and will be skipped if the number of 1Gi / 2Mi hugepages arent available. This allows us to run the same tests in an environment with (self hosted) and without hugepages (GH VM).

This patch adds a self hosted job which requires a GH environment. A GH environment can contain a set of approvers to allow execution. This environment should be created before this patch can be merged and tested.

Example of how we can use GH environments to allow a set of people to approve workflows: https://docs.google.com/document/d/1kWko-Hnne-BcuFvzEZPlmGxFQ9FSkTzPSzxP1m9xUuY/edit