### PR TITLE
set default failure policy to fail

### DIFF
--- a/cmd/installer/main.go
+++ b/cmd/installer/main.go
@@ -24,7 +24,7 @@ import (
 func main() {
 	namespace := flag.String("namespace", "kube-system", "Namespace in which all Kubernetes resources will be created.")
 	prefix := flag.String("name", "network-resources-injector", "Prefix added to the names of all created resources.")
-	failurePolicy := flag.String("failure-policy", "Ignore", "K8 admission controller failure policy to handle unrecognized errors and timeout errors")
+	failurePolicy := flag.String("failure-policy", "Fail", "K8 admission controller failure policy to handle unrecognized errors and timeout errors")
 	flag.Parse()
 
 	glog.Info("starting webhook installation")


### PR DESCRIPTION
now NRI adapted to use admission v1, so changing default `failurePolicy` into `Fail` as discussed [here](https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/103#issuecomment-857365865)

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>