### PR TITLE
Merge two config maps into one that defines control switches and user defined injections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ $RECYCLE.BIN/
 
 
 # End of https://www.gitignore.io/api/go,macos,linux,windows,visualstudiocode
+/test/tmp/*

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ spec:
 
 User Defined injections allows user to define additional injections (besides what's supported in NRI, such as ResourceName, Downward API volumes etc) in Kubernetes ConfigMap and request additional injection for individual pod based on pod label. Currently user defined injection only support injecting pod annotations.
 
-In order to use this feature, user needs to create the user defined injection ConfigMap with name `nri-user-defined-injections` in the namespace where NRI was deployed in (`kube-system` namespace is used when there is no `NAMESPACE` environment variable passed to NRI). The data entry in ConfigMap is in the format of key:value pair. Key is a user defined label that will be used to match with pod labels, Value is the actual injection in the format as defined by [RFC6902](https://tools.ietf.org/html/rfc6902) that will be applied to pod manifest. NRI would listen to the creation/update/deletion of this ConfigMap and update its internal data structure every 30 seconds so that subsquential creation of pods will be evaluated against the latest user defined injections.
+In order to use this feature, user needs to create the user defined injection ConfigMap with name `nri-control-switches` in the namespace where NRI was deployed in (`kube-system` namespace is used when there is no `NAMESPACE` environment variable passed to NRI). The ConfigMap is shared between control switches and user defined injections. The data entry in ConfigMap is in the format of key:value pair. Key is a user defined label that will be used to match with pod labels, Value is the actual injection in the format as defined by [RFC6902](https://tools.ietf.org/html/rfc6902) that will be applied to pod manifest. NRI would listen to the creation/update/deletion of this ConfigMap and update its internal data structure every 30 seconds so that subsequential creation of pods will be evaluated against the latest user defined injections.
 
 Metadata.Annotations in Pod definition is the only supported field for customization, whose `path` should be "/metadata/annotations".
 
@@ -263,10 +263,21 @@ Below is an example of user defined injection ConfigMap:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: nri-user-defined-injections
+  name: nri-control-switches
   namespace: kube-system
 data:
-  feature.pod.kubernetes.io_sriov-network: '{"op": "add", "path": "/metadata/annotations", "value": {"k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"}}'
+  config.json: |
+    {
+      "user-defined-injections": {
+        "feature.pod.kubernetes.io_sriov-network": {
+          "op": "add",
+          "path": "/metadata/annotations",
+          "value": {
+            "k8s.v1.cni.cncf.io/networks": "sriov-net-attach-def"
+          }
+        }
+      }
+    }
 ```
 
 `feature.pod.kubernetes.io/sriov-network` is a user defined label to request additional networks. Every pod that contains this label with a value set to `"true"` will be applied with the patch that's defined in the following json string.

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -31,13 +31,13 @@ import (
 
 	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/controlswitches"
 	netcache "github.com/k8snetworkplumbingwg/network-resources-injector/pkg/tools"
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/userdefinedinjections"
 	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/webhook"
 )
 
 const (
-	defaultClientCa               = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-	userDefinedInjectionConfigMap = "nri-user-defined-injections"
-	controlSwitchesConfigMap      = "nri-control-switches"
+	defaultClientCa          = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	controlSwitchesConfigMap = "nri-control-switches"
 )
 
 func main() {
@@ -104,6 +104,9 @@ func main() {
 	netAnnotationCache := netcache.Create()
 	netAnnotationCache.Start()
 	webhook.SetNetAttachDefCache(netAnnotationCache)
+
+	userInjections := userdefinedinjections.CreateUserInjectionsStructure()
+	webhook.SetUserInjectionStructure(userInjections)
 
 	go func() {
 		/* register handlers */
@@ -200,23 +203,14 @@ func main() {
 			cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(
 				context.Background(), controlSwitchesConfigMap, metav1.GetOptions{})
 			if err != nil {
-				glog.Warningf("Error within control switches map %s", err.Error())
 				if !errors.IsNotFound(err) {
-					glog.Info("Map with runtime configuration not available using default / CLI settings")
+					glog.Warningf("Error getting control switches configmap %s", err.Error())
 				}
 			}
+
 			// has to be called each time because we need to restore default config when map is empty
 			controlSwitches.ProcessControlSwitchesConfigMap(cm)
-
-			cm, err = clientset.CoreV1().ConfigMaps(namespace).Get(
-				context.Background(), userDefinedInjectionConfigMap, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					glog.Warningf("Failed to get configmap for user-defined injections: %v", err)
-					continue
-				}
-			}
-			webhook.SetCustomizedInjections(cm)
+			userInjections.SetUserDefinedInjections(cm)
 		}
 	}
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -202,13 +202,13 @@ func main() {
 		case <-time.After(30 * time.Second):
 			cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(
 				context.Background(), controlSwitchesConfigMap, metav1.GetOptions{})
-			if err != nil {
-				if !errors.IsNotFound(err) {
-					glog.Warningf("Error getting control switches configmap %s", err.Error())
-				}
+			// only in case of API errors report an error and do not restore default values
+			if err != nil && !errors.IsNotFound(err) {
+				glog.Warningf("Error getting control switches configmap %s", err.Error())
+				continue
 			}
 
-			// has to be called each time because we need to restore default config when map is empty
+			// to be called each time when map is present or not (in that case to restore default values)
 			controlSwitches.ProcessControlSwitchesConfigMap(cm)
 			userInjections.SetUserDefinedInjections(cm)
 		}

--- a/pkg/controlswitches/controlswitches.go
+++ b/pkg/controlswitches/controlswitches.go
@@ -22,11 +22,12 @@ import (
 
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/types"
 )
 
 const (
 	// control switch keys
-	controlSwitchesFileKey = "config.json"
 	controlSwitchesMainKey = "features"
 
 	// enableHugePageDownAPIKey feature name
@@ -161,7 +162,7 @@ func (switches *ControlSwitches) setFeatureToState(featureName string, switchObj
 // :param controlSwitchesCm - Kubernetes ConfigMap with control switches definition
 func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitchesCm *corev1.ConfigMap) {
 	var err error
-	if v, fileExists := controlSwitchesCm.Data[controlSwitchesFileKey]; fileExists {
+	if v, fileExists := controlSwitchesCm.Data[types.ConfigMapMainFileKey]; fileExists {
 		var obj map[string]json.RawMessage
 
 		if err = json.Unmarshal([]byte(v), &obj); err != nil {
@@ -185,6 +186,6 @@ func (switches *ControlSwitches) ProcessControlSwitchesConfigMap(controlSwitches
 			glog.Warningf("Map does not contains [%s]", controlSwitchesMainKey)
 		}
 	} else {
-		glog.Warningf("Map does not contains [%s]", controlSwitchesFileKey)
+		glog.Warningf("Map does not contains [%s]", types.ConfigMapMainFileKey)
 	}
 }

--- a/pkg/controlswitches/controlswitches_test.go
+++ b/pkg/controlswitches/controlswitches_test.go
@@ -263,7 +263,7 @@ var _ = Describe("Verify controlswitches package", func() {
 			It("Map with correct key, but without [features] inside", func() {
 				const value = `{
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",
@@ -298,7 +298,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableResourceNa": false
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",
@@ -330,7 +330,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableHonorExistingResources": true
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations"
@@ -362,7 +362,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableHonorExistingResources": false
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",
@@ -395,7 +395,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableHonorExistingResources": "isThisAnError"
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",
@@ -427,7 +427,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableHonorExistingResources": true
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",
@@ -459,7 +459,7 @@ var _ = Describe("Verify controlswitches package", func() {
 								"enableHonorExistingResources": false
 							},
 							"networkResourceNameKeys": ["k8s.v1.cni.cncf.io/resourceName", "k8s.v1.cni.cncf.io/bridgeName"],
-							"customInjection": {
+							"user-defined-injections": {
 								"network-resource-injector-pod-annotation": {
 									"op": "add",
 								 	"path": "/metadata/annotations",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,4 +23,12 @@ const (
 	Hugepages2MRequestPath = "hugepages_2M_request"
 	Hugepages1GLimitPath   = "hugepages_1G_limit"
 	Hugepages2MLimitPath   = "hugepages_2M_limit"
+	ConfigMapMainFileKey   = "config.json"
 )
+
+// JsonPatchOperation the JSON path operation
+type JsonPatchOperation struct {
+	Operation string      `json:"op"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+}

--- a/pkg/userdefinedinjections/userdefinedinjections.go
+++ b/pkg/userdefinedinjections/userdefinedinjections.go
@@ -1,0 +1,112 @@
+package userdefinedinjections
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/types"
+)
+
+const (
+	userDefinedInjectionsMainKey = "user-defined-injections"
+)
+
+// UserDefinedInjections user defined injections
+type UserDefinedInjections struct {
+	sync.Mutex
+	Patchs map[string]types.JsonPatchOperation
+}
+
+// CreateUserInjectionsStructure returns empty UserDefinedInjections structure
+func CreateUserInjectionsStructure() *UserDefinedInjections {
+	var userDefinedInjects = UserDefinedInjections{Patchs: make(map[string]types.JsonPatchOperation)}
+	return &userDefinedInjects
+}
+
+// SetUserDefinedInjections sets additional injections to be applied in Pod spec
+func (userDefinedInjects *UserDefinedInjections) SetUserDefinedInjections(injectionsCm *corev1.ConfigMap) {
+	if v, fileExists := injectionsCm.Data[types.ConfigMapMainFileKey]; fileExists {
+		var obj map[string]json.RawMessage
+		var err error
+		if err = json.Unmarshal([]byte(v), &obj); err != nil {
+			glog.Warningf("Error during json unmarshal of main: %v", err)
+			return
+		}
+
+		if userDefinedInjections, mainExists := obj[userDefinedInjectionsMainKey]; mainExists {
+			var userDefinedInjectionsObj map[string]json.RawMessage
+			if err = json.Unmarshal([]byte(userDefinedInjections), &userDefinedInjectionsObj); err != nil {
+				glog.Warningf("Error during json unmarshal of injections: %v", err)
+				return
+			}
+
+			// lock for writing
+			userDefinedInjects.Lock()
+			defer userDefinedInjects.Unlock()
+
+			var patch types.JsonPatchOperation
+			var userDefinedPatchs = userDefinedInjects.Patchs
+
+			for k, value := range userDefinedInjectionsObj {
+				existValue, exists := userDefinedPatchs[k]
+				// unmarshal userDefined injection to json patch
+				err := json.Unmarshal([]byte(value), &patch)
+				if err != nil {
+					glog.Errorf("Failed to unmarshal user-defined injection: %v", v)
+					continue
+				}
+				// metadata.Annotations is the only supported field for user definition
+				// jsonPatchOperation.Path should be "/metadata/annotations"
+				if patch.Path != "/metadata/annotations" {
+					glog.Errorf("Path: %v is not supported, only /metadata/annotations can be defined by user", patch.Path)
+					continue
+				}
+
+				if !exists || !reflect.DeepEqual(existValue, patch) {
+					glog.Infof("Initializing user-defined injections with key: %v, value: %v", k, v)
+					userDefinedPatchs[k] = patch
+				}
+			}
+
+			// remove stale entries from userDefined configMap
+			for k := range userDefinedPatchs {
+				if _, ok := userDefinedInjectionsObj[k]; ok {
+					continue
+				}
+				glog.Infof("Removing stale entry: %v from user-defined injections", k)
+				delete(userDefinedPatchs, k)
+			}
+		} else {
+			glog.Warningf("Map does not contains [%s]. Clear old entries.", userDefinedInjectionsMainKey)
+			userDefinedInjects.Patchs = make(map[string]types.JsonPatchOperation)
+		}
+	} else {
+		glog.Warningf("Map does not contains [%s]. Clear old entries", types.ConfigMapMainFileKey)
+		userDefinedInjects.Patchs = make(map[string]types.JsonPatchOperation)
+	}
+}
+
+// CreateUserDefinedPatch creates customized patch for the specified POD
+func (userDefinedInjects *UserDefinedInjections) CreateUserDefinedPatch(pod corev1.Pod) ([]types.JsonPatchOperation, error) {
+	var userDefinedPatch []types.JsonPatchOperation
+
+	// lock for reading
+	userDefinedInjects.Lock()
+	defer userDefinedInjects.Unlock()
+
+	for k, v := range userDefinedInjects.Patchs {
+		// The userDefinedInjects will be injected when:
+		// 1. Pod labels contain the patch key defined in userDefinedInjects
+		// 2. The value of patch key in pod labels(not in userDefinedInjects) is "true"
+		if podValue, exists := pod.ObjectMeta.Labels[k]; exists && strings.ToLower(podValue) == "true" {
+			userDefinedPatch = append(userDefinedPatch, v)
+		}
+	}
+
+	return userDefinedPatch, nil
+}

--- a/pkg/userdefinedinjections/userdefinedinjections_suite_test.go
+++ b/pkg/userdefinedinjections/userdefinedinjections_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controlswitches
+package userdefinedinjections
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestControlSwitches(t *testing.T) {
+func TestUserDefinedInjections(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controlswitches Suite")
+	RunSpecs(t, "UserDefinedInjections Suite")
 }

--- a/pkg/userdefinedinjections/userdefinedinjections_test.go
+++ b/pkg/userdefinedinjections/userdefinedinjections_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2021 Intel, Redhat Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userdefinedinjections
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/k8snetworkplumbingwg/network-resources-injector/pkg/types"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UserDefinedInjections", func() {
+	DescribeTable("Create user-defined patchs",
+
+		func(pod corev1.Pod, userDefinedInjectPatchs map[string]types.JsonPatchOperation, out []types.JsonPatchOperation) {
+			userDefinedInjects := CreateUserInjectionsStructure()
+			userDefinedInjects.Patchs = userDefinedInjectPatchs
+			appliedPatchs, _ := userDefinedInjects.CreateUserDefinedPatch(pod)
+			Expect(appliedPatchs).Should(Equal(out))
+		},
+		Entry(
+			"match pod label",
+			corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test",
+					Labels: map[string]string{"nri-inject-annotation": "true"},
+				},
+				Spec: corev1.PodSpec{},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"k8s.v1.cni.cncf.io/networks": "sriov-net"},
+				},
+			},
+			[]types.JsonPatchOperation{
+				{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"k8s.v1.cni.cncf.io/networks": "sriov-net"},
+				},
+			},
+		),
+		Entry(
+			"doesn't match pod label value",
+			corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test",
+					Labels: map[string]string{"nri-inject-annotation": "false"},
+				},
+				Spec: corev1.PodSpec{},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"k8s.v1.cni.cncf.io/networks": "sriov-net"},
+				},
+			},
+			nil,
+		),
+		Entry(
+			"doesn't match pod label key",
+			corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "test",
+					Labels: map[string]string{"nri-inject-labels": "true"},
+				},
+				Spec: corev1.PodSpec{},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"k8s.v1.cni.cncf.io/networks": "sriov-net"},
+				},
+			},
+			nil,
+		),
+	)
+
+	DescribeTable("Setting user-defined injections",
+		func(in *corev1.ConfigMap, existing map[string]types.JsonPatchOperation, out map[string]types.JsonPatchOperation) {
+			userDefinedInjects := CreateUserInjectionsStructure()
+			userDefinedInjects.Patchs = existing
+			userDefinedInjects.SetUserDefinedInjections(in)
+			Expect(userDefinedInjects.Patchs).Should(Equal(out))
+		},
+		Entry(
+			"patch - empty config map",
+			&corev1.ConfigMap{
+				Data: map[string]string{},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - empty config map",
+			&corev1.ConfigMap{
+				Data: map[string]string{},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net"},
+				},
+			},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - config map without main config.json key",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - config map without main config.json key",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net"},
+				},
+			},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - config map without userdefinedinjections key",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"custom\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - config map with errors in json path",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": 5, \"path\": \"/metadata/annotations\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - config map with incorrect json path - not /metadata/annotations",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/supprise\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - additional networks annotation",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": { \"k8s.v1.cni.cncf.io/networks\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"k8s.v1.cni.cncf.io/networks": "sriov-net"},
+				},
+			},
+		),
+		Entry(
+			"patch - default network annotation",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {\"v1.multus-cni.io/default-network\": \"sriov-net\" }}}}"},
+			},
+			map[string]types.JsonPatchOperation{},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net"},
+				},
+			},
+		),
+		Entry(
+			"patch - remove stale entry",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { }}"},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net"},
+				},
+			},
+			map[string]types.JsonPatchOperation{},
+		),
+		Entry(
+			"patch - overwrite existing userDefinedInjects",
+			&corev1.ConfigMap{
+				Data: map[string]string{
+					"config.json": "{\"user-defined-injections\": { \"nri-inject-annotation\": {\"op\": \"add\", \"path\": \"/metadata/annotations\", \"value\": {\"v1.multus-cni.io/default-network\": \"sriov-net-new\"}}}}"},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net-old"},
+				},
+			},
+			map[string]types.JsonPatchOperation{
+				"nri-inject-annotation": types.JsonPatchOperation{
+					Operation: "add",
+					Path:      "/metadata/annotations",
+					Value:     map[string]interface{}{"v1.multus-cni.io/default-network": "sriov-net-new"},
+				},
+			},
+		),
+	)
+})


### PR DESCRIPTION
This pull requests aims to merge User Defined Injections (UDI) ConfigMap into the control switches ConfigMap.

In result, there will be only one map to provided by the user. From the code perspective I refactored code by moving out from webhook.go all functions related to UDI into separate package called custominjections. This way, there is a clear information about package responsibility.

Fixes https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/61