### PR TITLE
Handle nri pod restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Currently supported arguments are below. If needed, detailed description is avai
 |network-resource-name-keys|k8s.v1.cni.cncf.io/resourceName|comma separated resource name keys|YES|
 |honor-resources|false|Honor the existing requested resources requests & limits|YES|
 
+NOTE: Network Resource Injector would not mutate pods in kube-system namespace.
+
 ### Features control switches
 It is possible to control some features of Network Resource Injector with runtime configuration. NRI is watching for a ConfigMap with name **nri-control-switches** that should be available in the same namespace as NRI (default is kube-system). Below is example with full configuration that sets all features to disable state. Not all values have to be defined. User can toggle only one feature leaving others in default state. By default state, one should understand state set during webhook initialization. Could be a state set by CLI argument, default argument embedded in code or environment variable.
 

--- a/deployments/webhook.yaml
+++ b/deployments/webhook.yaml
@@ -14,6 +14,12 @@ webhooks:
         namespace: ${NAMESPACE}
         path: "/mutate"
       caBundle: ${CA_BUNDLE}
+    namespaceSelector:
+      matchExpressions:
+        - key: "kubernetes.io/metadata.name"
+          operator: "NotIn"
+          values:
+            - "kube-system"
     rules:
       - operations: [ "CREATE" ]
         apiGroups: ["apps", ""]

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -107,6 +107,19 @@ func createMutatingWebhookConfiguration(certificate []byte, failurePolicyStr str
 	}
 	sideEffects := arv1.SideEffectClassNone
 	path := "/mutate"
+	namespaces := []string{"kube-system"}
+	if namespace != "kube-system" {
+		namespaces = append(namespaces, namespace)
+	}
+	namespaceSelector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   namespaces,
+			},
+		},
+	}
 	configuration := &arv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: configName,
@@ -128,6 +141,7 @@ func createMutatingWebhookConfiguration(certificate []byte, failurePolicyStr str
 				FailurePolicy:           &failurePolicy,
 				AdmissionReviewVersions: []string{"v1"},
 				SideEffects:             &sideEffects,
+				NamespaceSelector:       &namespaceSelector,
 				Rules: []arv1.RuleWithOperations{
 					arv1.RuleWithOperations{
 						Operations: []arv1.OperationType{arv1.Create},


### PR DESCRIPTION
This PR avoids nri webhook service from being invoked for nri pods and any other pod in kube-system. 

Fixes: #119 