### PR TITLE
Use deployment for network-resource-injector and support pdb

### DIFF
--- a/deployments/auth.yaml
+++ b/deployments/auth.yaml
@@ -50,20 +50,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: network-resources-injector-certificates
-rules:
-- apiGroups:
-  - certificates.k8s.io
-  resources:
-  - certificatesigningrequests
-  - certificatesigningrequests/approval
-  - signers
-  verbs:
-  - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
   name: network-resources-injector-secrets
 rules:
 - apiGroups:
@@ -126,19 +112,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: network-resources-injector-certificates-role-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: network-resources-injector-certificates
-subjects:
-- kind: ServiceAccount
-  name: network-resources-injector-sa
-  namespace: kube-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: network-resources-injector-secrets-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -187,3 +160,4 @@ subjects:
 - kind: ServiceAccount
   name: network-resources-injector-sa
   namespace: kube-system
+

--- a/deployments/pdb.yaml
+++ b/deployments/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: network-resources-injector-pdb
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: network-resources-injector 

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -12,70 +12,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: network-resources-injector
   name: network-resources-injector
   namespace: kube-system
 spec:
-  serviceAccount: network-resources-injector-sa
-  containers:
-  - name: webhook-server
-    image: network-resources-injector:latest
-    imagePullPolicy: IfNotPresent
-    command:
-    - webhook
-    args:
-    - -bind-address=0.0.0.0
-    - -port=8443
-    - -tls-private-key-file=/etc/tls/tls.key
-    - -tls-cert-file=/etc/tls/tls.crt
-    - -logtostderr
-    env:
-    - name: NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    securityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
-      capabilities:
-        drop:
-          - ALL
-        add: ["NET_BIND_SERVICE"]
-      readOnlyRootFilesystem: true
-      allowPrivilegeEscalation: false
-    volumeMounts:
-    - mountPath: /etc/tls
-      name: tls
-    resources:
-      requests:
-        memory: "50Mi"
-        cpu: "250m"
-      limits:
-        memory: "200Mi"
-        cpu: "500m"
-  initContainers:
-  - name: installer
-    image: network-resources-injector:latest
-    imagePullPolicy: IfNotPresent
-    command:
-    - installer
-    args:
-    - -name=network-resources-injector
-    - -namespace=kube-system
-    - -alsologtostderr
-    securityContext:
-      runAsUser: 10000
-      runAsGroup: 10000
-    volumeMounts:
-    - name: tls
-      mountPath: /etc/tls
-  volumes:
-  - name: tls
-    emptyDir: {}
+  replicas: 2
+  selector:
+    matchLabels:
+      app: network-resources-injector
+  template:
+    metadata:
+      labels:
+        app: network-resources-injector
+    spec:
+      serviceAccount: network-resources-injector-sa
+      containers:
+      - name: webhook-server
+        image: network-resources-injector:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - webhook
+        args:
+        - -bind-address=0.0.0.0
+        - -port=8443
+        - -tls-private-key-file=/etc/tls/tls.key
+        - -tls-cert-file=/etc/tls/tls.crt
+        - -logtostderr
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+          capabilities:
+            drop:
+              - ALL
+            add: ["NET_BIND_SERVICE"]
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /etc/tls
+          name: tls
+        resources:
+          requests:
+            memory: "50Mi"
+            cpu: "250m"
+          limits:
+            memory: "200Mi"
+            cpu: "500m"
+      initContainers:
+      - name: installer
+        image: network-resources-injector:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - installer
+        args:
+        - -name=network-resources-injector
+        - -namespace=kube-system
+        - -alsologtostderr
+        securityContext:
+          runAsUser: 10000
+          runAsGroup: 10000
+        volumeMounts:
+        - name: tls
+          mountPath: /etc/tls
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      volumes:
+      - name: tls
+        emptyDir: {}
 
 # For third-party certificate, use secret resource
 # instead of self-generated one from installer as below:

--- a/pkg/installer/installer.go
+++ b/pkg/installer/installer.go
@@ -16,9 +16,12 @@ package installer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
+	"time"
 
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
@@ -32,6 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -40,6 +44,7 @@ var (
 	clientset kubernetes.Interface
 	namespace string
 	prefix    string
+	podName   string
 )
 
 const keyBitLength = 3072
@@ -232,6 +237,7 @@ func Install(k8sNamespace, namePrefix, failurePolicy string) {
 	if err != nil {
 		glog.Fatalf("error setting up Kubernetes client: %s", err)
 	}
+	populatePodName()
 
 	namespace = k8sNamespace
 	prefix = namePrefix
@@ -256,6 +262,19 @@ func Install(k8sNamespace, namePrefix, failurePolicy string) {
 	}
 	glog.Infof("signed certificate successfully obtained")
 
+	if err = createSecret(context.Background(), certificate, key, "tls.crt", "tls.key"); err != nil {
+		// As expected only one initContainer will succeed in creating secret.
+		glog.Errorf("Failed creating secret: %v", err)
+		// Wait for the secret to be created by the other initContainer and write
+		// key and certificate to file.
+		err = waitForCertDetailsUpdation()
+		if err != nil {
+			glog.Fatalf("Error occured while waiting for secret creation: %s", err)
+		}
+		return
+	}
+	glog.Info("Secret created successfully!")
+
 	err = writeToFile(certificate, key, "tls.crt", "tls.key")
 	if err != nil {
 		glog.Fatalf("error writing certificate and key to files: %s", err)
@@ -278,3 +297,84 @@ func Install(k8sNamespace, namePrefix, failurePolicy string) {
 
 	glog.Infof("all resources created successfully")
 }
+
+func createSecret(ctx context.Context, certificate, key []byte, certFilename, keyFilename string) error {
+	ownerRef, err := getOwnerReference()
+	if err != nil {
+		glog.Fatalf("Failed fetching owner reference for the pod:%v", err)
+	}
+	// Set owner reference so that on deleting deployment the secret is also deleted,
+	// with this every new installation will create a new certificate and webhook config.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "network-resources-injector",
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+		Data: map[string][]byte{
+			certFilename: certificate,
+			keyFilename:  key,
+		},
+	}
+	_, err = clientset.CoreV1().Secrets("kube-system").Create(ctx, secret, metav1.CreateOptions{})
+	return err
+}
+
+func getOwnerReference() (*metav1.OwnerReference, error) {
+	b, err := clientset.CoreV1().RESTClient().Get().Resource("pods").
+		Name(podName).Namespace("kube-system").DoRaw(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	var pod corev1.Pod
+	err = json.Unmarshal(b, &pod)
+	if err != nil {
+		glog.Info(err)
+		return nil, err
+	}
+	var ownerRef metav1.OwnerReference
+	for _, owner := range pod.OwnerReferences {
+		if owner.Kind == "ReplicaSet" {
+			ownerRef = metav1.OwnerReference{
+				Kind:       owner.Kind,
+				APIVersion: owner.APIVersion,
+				Name:       owner.Name,
+				UID:        owner.UID,
+			}
+		}
+	}
+	return &ownerRef, nil
+}
+
+func populatePodName() {
+	var isPodNameAvailable bool
+	podName, isPodNameAvailable = os.LookupEnv("POD_NAME")
+	if !isPodNameAvailable {
+		glog.Fatal(errors.New("pod name not set as environment variable"))
+	}
+	glog.Info("Pod Name set:", podName)
+	// pod, err := clientset.CoreV1().Pods(namespace).Get(context.TODO(), leaseName, metav1.GetOptions{TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"}})
+
+}
+
+func waitForCertDetailsUpdation() error {
+	return wait.Poll(5*time.Second, 300*time.Second, writeCertDetailsFromSecret)
+}
+
+func writeCertDetailsFromSecret() (bool, error) {
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(context.Background(), "network-resources-injector", metav1.GetOptions{})
+	if err != nil {
+		return false, err
+	}
+	var tlsKey, tlsCertificate []byte
+	for key, element := range secret.Data {
+		if key == "tls.key" {
+			tlsKey = element
+		} else if key == "tls.crt" {
+			tlsCertificate = element
+		}
+	}
+	writeToFile(tlsCertificate, tlsKey, "tls.crt", "tls.key")
+	glog.Info("Certificate details written to file")
+	return true, nil
+}
+


### PR DESCRIPTION
This changeset consists of following changes:

-  Use deployment instead of a pod 
- Support pdb
- Change in initcontainer code for supporting deployment: 
   The existing code would only have one initcontainer which creates certificate/key and webhook config with the generated 
   key. This would cause issues with deployments as multiple initcontainer's would race for creation of certificate/key and 
   webhook configuration. The new implementation uses secret to share certificate and key across all initcontainers and also 
   uses the secret resource as a lock also(ie to decide which initcontainer actually creates the certificate/key and webhook 
   config, avoiding a race).

Fixes: https://github.com/k8snetworkplumbingwg/network-resources-injector/issues/117