### PR TITLE
health check for webhook server

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Currently supported arguments are below. If needed, detailed description is avai
 |tls-private-key-file|key.pem|File containing the default x509 private key matching --tls-cert-file.|NO|
 |insecure|false|Disable adding client CA to server TLS endpoint|NO|
 |client-ca|""|File containing client CA. This flag is repeatable if more than one client CA needs to be added to server|NO|
+|health-check-port|8444|The port to use for health check monitoring.|NO|
 |injectHugepageDownApi|false|Enable hugepage requests and limits into Downward API.|YES|
 |network-resource-name-keys|k8s.v1.cni.cncf.io/resourceName|comma separated resource name keys|YES|
 |honor-resources|false|Honor the existing requested resources requests & limits|YES|

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -41,6 +41,7 @@ spec:
         - -port=8443
         - -tls-private-key-file=/etc/tls/tls.key
         - -tls-cert-file=/etc/tls/tls.crt
+        - -health-check-port=8444
         - -logtostderr
         env:
         - name: NAMESPACE
@@ -66,6 +67,12 @@ spec:
           limits:
             memory: "200Mi"
             cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8444
+          initialDelaySeconds: 10
+          periodSeconds: 5
       initContainers:
       - name: installer
         image: network-resources-injector:latest


### PR DESCRIPTION
This change adds support for health check endpoint for webhook.
Enabling of health check is made optional since kubelet doesn't support mTLS for probes, so it will only work for "insecure" mode. On enabling health check, client authentication is disabled.

#124 

Signed-off-by: Ravindra Thakur <ravindra.nath.thakur@est.tech>