### PR TITLE
Fix HTTP/2 disablement

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -169,11 +169,12 @@ func main() {
 				},
 				GetCertificate: keyPair.GetCertificateFunc(),
 			},
+			// CVE-2023-39325 https://github.com/golang/go/issues/63417
+			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),
 		}
 
-		// CVE-2023-39325 https://github.com/golang/go/issues/63417
-		if !*enableHTTP2 {
-			httpServer.TLSConfig.NextProtos = []string{"http/1.1"}
+		if *enableHTTP2 {
+			httpServer.TLSNextProto = nil
 		}
 
 		err := httpServer.ListenAndServeTLS("", "")


### PR DESCRIPTION
In commit 4371417 we disabled HTTP/2 by default as a remediation for CVE-2023-39325. An HTTP connection test using curl suggested at the time that the server only accepted HTTP/1.1 even though the client offered h2 and HTTP/1.1:

    $ curl --http2 https://localhost:8443 2>&1 | grep -i alpn
    * ALPN: offers h2,http/1.1
    * ALPN: server accepted http/1.1

It so happens that the peers can still negotiate h2:

    $ openssl s_client -connect localhost:8443 -alpn "h2"
    [...]
    ALPN protocol: h2
    [...]

This commit fixes this issue, completely disabling HTTP/2 for good now:

    $ for PROTO in h3 h2 http/1.1 http/1.0; do openssl s_client -connect localhost:8443 -alpn "${PROTO}" 2>/dev/null | grep -i alpn; done
    No ALPN negotiated
    No ALPN negotiated
    ALPN protocol: http/1.1
    No ALPN negotiate