### PR TITLE
Dockerfile: bump build dependency for Dockerfile to use golang 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine as builder
+FROM golang:1.22-alpine as builder
 COPY . /usr/src/network-resources-injector
 WORKDIR /usr/src/network-resources-injector
 RUN apk add --update --virtual build-dependencies build-base bash && \


### PR DESCRIPTION
Bump the build dependency to go 1.22 (released 2024.02.06).

The project would still build fine with 1.21, but the openshift downstream fork already requires 1.22 (due to [1]).

Alternatives to this patch would be try to adjust [1] to not require 1.22 in openshift downstream. But it seems easy enough to bump the build dependency.

[1] https://github.com/openshift/sriov-dp-admission-controller/commit/bbb31269474d5be6df3d0de60f71aec62eafe7b0