### PR TITLE
chore: align runners with ubuntu 24.04

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.20.x, 1.21.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     env:
       GO111MODULE: on

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   e2e-test-cloud:
     name: E2E test cloud (GitHub VM)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         go-version: ['1.20', '1.21']

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -10,7 +10,7 @@ on:
       - master
 jobs:
   build-and-push-image-nri:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -10,7 +10,7 @@ on:
       - v*
 jobs:
   build-and-push-image-nri:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu-20.04 is deprecated. align runners to use
ubuntu-24.04