### PR TITLE
add --tls-curve-preferences flag for webhook TLS hardening

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -57,6 +57,12 @@ func main() {
 		"Comma-separated list of TLS 1.2 and earlier cipher suites (for example TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256). Insecure cipher suites are rejected. If empty, uses Go runtime defaults.")
 	tlsMinVersion := flag.String("tls-min-version", "",
 		"Minimum TLS version (VersionTLS12, VersionTLS13). Values below VersionTLS12 are rejected. If empty, uses component-base default (VersionTLS12).")
+	tlsCurvePreferences := flag.String("tls-curve-preferences", "",
+		"Comma-separated list of numeric Go crypto/tls CurveID values, "+
+			"as the allowed key exchange mechanisms for the server. "+
+			"The supported values depend on the Go version used. "+
+			"See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. "+
+			"If empty, uses Go runtime defaults.")
 
 	// do initialization of control switches flags
 	controlSwitches := controlswitches.SetupControlSwitchesFlags()
@@ -129,7 +135,12 @@ func main() {
 		glog.Fatalf("invalid tls-min-version flag: %v", err)
 	}
 
-	glog.Infof("TLS config: minVersion=%#x, cipherSuites=%v", minVersion, cipherSuites)
+	curvePreferences, err := webhook.ParseCurvePreferences(*tlsCurvePreferences)
+	if err != nil {
+		glog.Fatalf("Error parsing TLS curve preferences: %v", err)
+	}
+
+	glog.Infof("TLS config: minVersion=%#x, cipherSuites=%v, curvePreferences=%v", minVersion, cipherSuites, curvePreferences)
 
 	/* init API client */
 	clientset := webhook.SetupInClusterClient()
@@ -169,11 +180,12 @@ func main() {
 			MaxHeaderBytes:    1 << 20,
 			ReadHeaderTimeout: 1 * time.Second,
 			TLSConfig: &tls.Config{
-				ClientAuth:     webhook.GetClientAuth(*insecure),
-				MinVersion:     minVersion,
-				ClientCAs:      clientCaPool.GetCertPool(),
-				CipherSuites:   cipherSuites,
-				GetCertificate: keyPair.GetCertificateFunc(),
+				ClientAuth:       webhook.GetClientAuth(*insecure),
+				MinVersion:       minVersion,
+				ClientCAs:        clientCaPool.GetCertPool(),
+				CipherSuites:     cipherSuites,
+				CurvePreferences: curvePreferences,
+				GetCertificate:   keyPair.GetCertificateFunc(),
 			},
 			// CVE-2023-39325 https://github.com/golang/go/issues/63417
 			TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -45,6 +45,7 @@ spec:
         # Optional TLS hardening flags:
         # - -tls-min-version=VersionTLS13
         # - -tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        # - -tls-curve-preferences=29,23,24
         - -logtostderr
         env:
         - name: NAMESPACE

--- a/pkg/webhook/tlsconfig.go
+++ b/pkg/webhook/tlsconfig.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"crypto/tls"
 	"fmt"
+	"strconv"
 	"strings"
 
 	cliflag "k8s.io/component-base/cli/flag"
@@ -49,6 +50,35 @@ func ParseTLSCipherSuites(cipherSuites string) ([]uint16, error) {
 		return nil, nil
 	}
 	return CipherNamesToIDs(strings.Split(trimmed, ","))
+}
+
+// ParseCurvePreferences parses a comma-separated list of numeric TLS CurveID
+// values (as defined in crypto/tls) and returns them as []tls.CurveID.
+// For example "29,23,24" selects X25519, CurveP256, and CurveP384.
+// The supported values depend on the Go version used.
+// See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version.
+// Returns nil if the input is empty.
+func ParseCurvePreferences(curvePreferences string) ([]tls.CurveID, error) {
+	trimmed := strings.TrimSpace(curvePreferences)
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	curves := make([]tls.CurveID, 0, len(parts))
+	for _, part := range parts {
+		s := strings.TrimSpace(part)
+		if s == "" {
+			return nil, fmt.Errorf("empty TLS CurveID value")
+		}
+		v, err := strconv.ParseUint(s, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TLS CurveID value %q: %w", s, err)
+		}
+		curves = append(curves, tls.CurveID(v))
+	}
+
+	return curves, nil
 }
 
 // TLSVersionToGo converts a TLS version string (for example "VersionTLS12") to

--- a/pkg/webhook/tlsconfig_test.go
+++ b/pkg/webhook/tlsconfig_test.go
@@ -152,6 +152,89 @@ var _ = Describe("TLS Configuration", func() {
 		})
 	})
 
+	Describe("ParseCurvePreferences", func() {
+		It("should return nil for empty input", func() {
+			curves, err := ParseCurvePreferences("")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(curves).To(BeNil())
+		})
+
+		It("should return nil for whitespace-only input", func() {
+			curves, err := ParseCurvePreferences("   ")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(curves).To(BeNil())
+		})
+
+		DescribeTable("valid single numeric CurveID",
+			func(input string, expected tls.CurveID) {
+				curves, err := ParseCurvePreferences(input)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(curves).To(HaveLen(1))
+				Expect(curves[0]).To(Equal(expected))
+			},
+			Entry("29 (X25519)", "29", tls.X25519),
+			Entry("23 (CurveP256)", "23", tls.CurveP256),
+			Entry("24 (CurveP384)", "24", tls.CurveP384),
+			Entry("25 (CurveP521)", "25", tls.CurveP521),
+			Entry("4588 (X25519MLKEM768)", "4588", tls.X25519MLKEM768),
+		)
+
+		It("should parse multiple comma-separated numeric CurveIDs", func() {
+			curves, err := ParseCurvePreferences("29,23,24")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(curves).To(Equal([]tls.CurveID{
+				tls.X25519,
+				tls.CurveP256,
+				tls.CurveP384,
+			}))
+		})
+
+		It("should trim whitespace around numeric CurveIDs", func() {
+			curves, err := ParseCurvePreferences("29, 23")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(curves).To(Equal([]tls.CurveID{
+				tls.X25519,
+				tls.CurveP256,
+			}))
+		})
+
+		It("should accept any valid uint16 CurveID without validation", func() {
+			curves, err := ParseCurvePreferences("9999")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(curves).To(Equal([]tls.CurveID{tls.CurveID(9999)}))
+		})
+
+		It("should return an error for values exceeding uint16 range", func() {
+			_, err := ParseCurvePreferences("70000")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid TLS CurveID value"))
+		})
+
+		It("should return an error for negative values", func() {
+			_, err := ParseCurvePreferences("-1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid TLS CurveID value"))
+		})
+
+		It("should return an error for non-numeric string", func() {
+			_, err := ParseCurvePreferences("X25519")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid TLS CurveID value"))
+		})
+
+		It("should return an error for trailing separators", func() {
+			_, err := ParseCurvePreferences("29,")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty TLS CurveID value"))
+		})
+
+		It("should return an error for repeated separators", func() {
+			_, err := ParseCurvePreferences("29,,23")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("empty TLS CurveID value"))
+		})
+	})
+
 	Describe("TLSVersionToGo", func() {
 		DescribeTable("valid TLS versions",
 			func(version string, expected uint16) {


### PR DESCRIPTION
Allow administrators to control the TLS curve/group negotiation order via a new CLI flag, complementing the existing --tls-cipher-suites and --tls-min-version flags. Supported groups follow the IANA "TLS Supported Groups" registry: X25519, secp256r1, secp384r1, secp521r1, X25519MLKEM768.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--tls-curve-preferences` flag to configure allowed TLS curve preferences for the webhook server.
* **Deployment Changes**
  * Updated the server Kubernetes manifest to include an optional (commented) `tls-curve-preferences` setting.
* **Tests**
  * Added coverage for parsing TLS curve preferences, including valid formats, whitespace handling, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->