### PR TITLE
webhook: Skip duplicate podnetinfo volume and mount injection

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -57,6 +58,7 @@ const (
 	defaultNetworkAnnotationKey = "v1.multus-cni.io/default-network"
 	metadataAnnotationsPath     = "/metadata/annotations"
 	patchOperationAdd           = "add"
+	podNetInfoVolumeName        = "podnetinfo"
 )
 
 var (
@@ -429,6 +431,13 @@ func patchEmptyResources(patch []types.JSONPatchOperation, containerIndex uint, 
 }
 
 func addVolDownwardAPI(patch []types.JSONPatchOperation, hugepageResourceList []hugepageResourceData, pod *corev1.Pod) []types.JSONPatchOperation {
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == podNetInfoVolumeName {
+			glog.Infof("%s volume already exists, skipping injection", podNetInfoVolumeName)
+			return patch
+		}
+	}
+
 	if len(pod.Spec.Volumes) == 0 {
 		patch = append(patch, types.JSONPatchOperation{
 			Operation: "add",
@@ -481,7 +490,7 @@ func addVolDownwardAPI(patch []types.JSONPatchOperation, hugepageResourceList []
 		DownwardAPI: &dAPIVolSource,
 	}
 	vol := corev1.Volume{
-		Name:         "podnetinfo",
+		Name:         podNetInfoVolumeName,
 		VolumeSource: volSource,
 	}
 
@@ -496,11 +505,17 @@ func addVolDownwardAPI(patch []types.JSONPatchOperation, hugepageResourceList []
 
 func addVolumeMount(patch []types.JSONPatchOperation, containers []corev1.Container) []types.JSONPatchOperation {
 	vm := corev1.VolumeMount{
-		Name:      "podnetinfo",
+		Name:      podNetInfoVolumeName,
 		ReadOnly:  true,
 		MountPath: types.DownwardAPIMountPath,
 	}
 	for containerIndex, container := range containers {
+		if slices.ContainsFunc(container.VolumeMounts, func(vm corev1.VolumeMount) bool {
+			return vm.Name == podNetInfoVolumeName
+		}) {
+			continue
+		}
+
 		if len(container.VolumeMounts) == 0 {
 			patch = append(patch, types.JSONPatchOperation{
 				Operation: "add",

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -173,6 +173,54 @@ var _ = Describe("Webhook", func() {
 			Entry("malformed hugepage", "hugepage-1Gi", "", false),
 			Entry("empty string", "", "", false),
 		)
+
+		Describe("Volume duplicate prevention", func() {
+			Context("addVolDownwardAPI", func() {
+				It("should skip injection when podnetinfo volume exists", func() {
+					pod := &corev1.Pod{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{Name: "podnetinfo"},
+							},
+						},
+					}
+					patch := addVolDownwardAPI([]nritypes.JSONPatchOperation{}, []hugepageResourceData{}, pod)
+					Expect(patch).To(BeEmpty())
+				})
+
+				It("should inject when podnetinfo volume does not exist", func() {
+					pod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+						Spec:       corev1.PodSpec{Volumes: []corev1.Volume{}},
+					}
+					patch := addVolDownwardAPI([]nritypes.JSONPatchOperation{}, []hugepageResourceData{}, pod)
+					Expect(patch).NotTo(BeEmpty())
+				})
+			})
+
+			Context("addVolumeMount", func() {
+				It("should skip containers with podnetinfo mount", func() {
+					containers := []corev1.Container{
+						{
+							Name: "test",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "podnetinfo"},
+							},
+						},
+					}
+					patch := addVolumeMount([]nritypes.JSONPatchOperation{}, containers)
+					Expect(patch).To(BeEmpty())
+				})
+
+				It("should inject mount when podnetinfo mount does not exist", func() {
+					containers := []corev1.Container{
+						{Name: "test", VolumeMounts: []corev1.VolumeMount{}},
+					}
+					patch := addVolumeMount([]nritypes.JSONPatchOperation{}, containers)
+					Expect(patch).NotTo(BeEmpty())
+				})
+			})
+		})
 	})
 
 	Describe("Hugepage Detection Logic", func() {


### PR DESCRIPTION
Multiple webhook instances may run concurrently, causing the webhook to fire multiple times for the same pod. Resource injection already handles this by checking for existing resources before adding them. Volume injection lacked this protection, causing pod creation failures when podnetinfo volume or mounts were injected more than once [1].

Add duplicate-detection logic to volume and volume mount injection.

[1] https://redhat.atlassian.net/browse/CNV-91360


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate pod volume and volume-mount injections, making webhook updates idempotent.
  * Keeps existing pod configuration unchanged when the target volume or mount is already present.
* **Tests**
  * Added coverage for duplicate-prevention behavior to confirm patches are only applied when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->