### PR TITLE
Validate network selection fields and reject cross-namespace NAD refrences

### DIFF
--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -61,6 +61,7 @@ const (
 
 var (
 	HugepageRegex         = regexp.MustCompile(`^hugepages-(.+)$`)
+	validNameRegex        = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 	clientset             kubernetes.Interface
 	nadCache              netcache.NetAttachDefCacheService
 	userDefinedInjections *userdefinedinjections.UserDefinedInjections
@@ -271,7 +272,26 @@ func parsePodNetworkSelections(podNetworks, defaultNamespace string) ([]*multus.
 		}
 	}
 
-	/* fill missing namespaces with default value */
+	for _, networkSelection := range networkSelections {
+		if networkSelection == nil {
+			err := errors.New("invalid network selection: null element in list")
+			glog.Error(err)
+			return nil, err
+		}
+		for _, pair := range []struct{ label, value string }{
+			{"name", networkSelection.Name},
+			{"namespace", networkSelection.Namespace},
+			{"interface", networkSelection.InterfaceRequest},
+		} {
+			if pair.value != "" && !validNameRegex.MatchString(pair.value) {
+				err := errors.Errorf("invalid network selection element: %s '%s' contains invalid characters", pair.label, pair.value)
+				glog.Error(err)
+				return nil, err
+			}
+		}
+	}
+
+	/* fill missing namespaces with default value and reject cross-namespace references */
 	for _, networkSelection := range networkSelections {
 		if networkSelection.Namespace == "" {
 			if defaultNamespace == "" {
@@ -286,6 +306,12 @@ func parsePodNetworkSelections(podNetworks, defaultNamespace string) ([]*multus.
 			} else {
 				networkSelection.Namespace = defaultNamespace
 			}
+		} else if networkSelection.Namespace != defaultNamespace {
+			err := errors.Errorf(
+				"cross-namespace network attachment definition reference '%s/%s' is not allowed for namespace '%s'",
+				networkSelection.Namespace, networkSelection.Name, defaultNamespace)
+			glog.Error(err)
+			return nil, err
 		}
 	}
 
@@ -322,16 +348,6 @@ func parsePodNetworkSelectionElement(selection, defaultNamespace string) (*multu
 		err := errors.Errorf("invalid network selection element - more than one '@' rune in: '%s'", selection)
 		glog.Info(err)
 		return networkSelectionElement, err
-	}
-
-	validNameRegex, _ := regexp.Compile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
-	for _, unit := range []string{namespace, name, netInterface} {
-		ok := validNameRegex.MatchString(unit)
-		if !ok && len(unit) > 0 {
-			err := errors.Errorf("at least one of the network selection units is invalid: error found at '%s'", unit)
-			glog.Info(err)
-			return networkSelectionElement, err
-		}
 	}
 
 	networkSelectionElement = &multus.NetworkSelectionElement{

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -429,10 +429,10 @@ var _ = Describe("Webhook", func() {
 		),
 		Entry(
 			"csv - correct ns/net@if format",
-			"ns1/net1@eth0",
+			"default/net1@eth0",
 			[]*types.NetworkSelectionElement{
 				{
-					Namespace:        "ns1",
+					Namespace:        "default",
 					Name:             "net1",
 					InterfaceRequest: "eth0",
 				},
@@ -465,10 +465,10 @@ var _ = Describe("Webhook", func() {
 		),
 		Entry(
 			"csv - correct ns/net format",
-			"ns1/net1",
+			"default/net1",
 			[]*types.NetworkSelectionElement{
 				{
-					Namespace:        "ns1",
+					Namespace:        "default",
 					Name:             "net1",
 					InterfaceRequest: "",
 				},
@@ -477,10 +477,10 @@ var _ = Describe("Webhook", func() {
 		),
 		Entry(
 			"csv - correct multiple networks format",
-			"ns1/net1,net2",
+			"default/net1,net2",
 			[]*types.NetworkSelectionElement{
 				{
-					Namespace:        "ns1",
+					Namespace:        "default",
 					Name:             "net1",
 					InterfaceRequest: "",
 				},
@@ -518,7 +518,7 @@ var _ = Describe("Webhook", func() {
 		),
 		Entry(
 			"json - correct example",
-			`[{"name": "net1"},{"name": "net2", "namespace": "ns1"}]`,
+			`[{"name": "net1"},{"name": "net2", "namespace": "default"}]`,
 			[]*types.NetworkSelectionElement{
 				{
 					Namespace:        "default",
@@ -526,12 +526,87 @@ var _ = Describe("Webhook", func() {
 					InterfaceRequest: "",
 				},
 				{
-					Namespace:        "ns1",
+					Namespace:        "default",
 					Name:             "net2",
 					InterfaceRequest: "",
 				},
 			},
 			false,
 		),
+		Entry(
+			"json - path traversal in namespace",
+			`[{"name": "net1", "namespace": "../../api/v1"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - path traversal in name",
+			`[{"name": "../secrets", "namespace": "default"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - uppercase in namespace",
+			`[{"name": "net1", "namespace": "Tenant-A"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - uppercase in name",
+			`[{"name": "MyNetwork", "namespace": "default"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - special characters in name",
+			`[{"name": "net;drop", "namespace": "default"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - spaces in namespace",
+			`[{"name": "net1", "namespace": "my namespace"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - invalid interface characters",
+			`[{"name": "net1", "namespace": "default", "interface": "../../evil"}]`,
+			emptyList,
+			true,
+		),
+		Entry(
+			"json - null element in array",
+			`[{"name": "net1"}, null]`,
+			emptyList,
+			true,
+		),
+	)
+
+	DescribeTable("Cross-namespace NAD reference rejection",
+		func(in string, podNamespace string, shouldFail bool) {
+			selections, err := parsePodNetworkSelections(in, podNamespace)
+			if shouldFail {
+				Expect(err).To(HaveOccurred(), "expected cross-namespace NAD reference to be rejected")
+				Expect(selections).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(selections).NotTo(BeEmpty())
+			}
+		},
+		Entry("csv - explicit cross-namespace reference",
+			"other-ns/net1", "tenant-a", true),
+		Entry("json - explicit cross-namespace reference",
+			`[{"name": "net1", "namespace": "other-ns"}]`, "tenant-a", true),
+		Entry("json - multiple networks with one cross-namespace",
+			`[{"name": "net1"}, {"name": "net2", "namespace": "other-ns"}]`, "tenant-a", true),
+		Entry("csv - same namespace explicit",
+			"tenant-a/net1", "tenant-a", false),
+		Entry("csv - no namespace uses default",
+			"net1", "tenant-a", false),
+		Entry("json - same namespace explicit",
+			`[{"name": "net1", "namespace": "tenant-a"}]`, "tenant-a", false),
+		Entry("json - no namespace uses default",
+			`[{"name": "net1"}]`, "tenant-a", false),
 	)
 })


### PR DESCRIPTION
Move character validation (lowercase alphanumeric + hyphens) from the CSV-only parsePodNetworkSelectionElement into parsePodNetworkSelections so it covers both JSON and CSV annotation formats. Add nil-element guard for JSON arrays. Reject NAD references where the specified namespace differs from the pod's own namespace.

_Cross-namespace NAD references are now rejected unconditionally. This is a breaking change for users who reference NADs from other namespaces - if needed, a --namespace-isolation flag (mirroring Multus's pattern) can be added in a follow-up to make this configurable._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for network selection names, namespaces, and interfaces.
  * Rejected empty values, null entries, missing fields, invalid characters, path traversal patterns, and overlong values.
  * Improved handling of invalid or empty network selection input.
  * Prevented duplicate webhook volume and volume-mount injection when equivalent entries already exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->