### PR TITLE
webhook, deployments: Use tcpSocket readiness probe on admission port

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -106,9 +106,6 @@ func main() {
 			mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusOK)
 			})
-			mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			})
 			err := http.ListenAndServe(addr, mux)
 			if err != nil {
 				glog.Fatalf("error starting health check server: %v", err)

--- a/deployments/server.yaml
+++ b/deployments/server.yaml
@@ -82,11 +82,13 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
         readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8444
+          failureThreshold: 3
+          tcpSocket:
+            port: 8443
           initialDelaySeconds: 5
           periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
       initContainers:
       - name: installer
         image: network-resources-injector:latest


### PR DESCRIPTION
The previously added /readyz readiness probe gives a false readiness signal, so replace it with a tcpSocket probe on the admission port (:8443) that actually reflects the webhook being able to serve requests.

The /readyz endpoint lived on the health server (:8444), always returned 200, and that server starts before TLS is loaded, the NAD cache is populated, and ListenAndServeTLS begins on :8443. Since the Service targets 8443, /readyz could report Ready while the apiserver still gets connection-refused on /mutate; initialDelaySeconds only hid the race, it did not close it. Probing :8443 over TCP tracks the admission port directly [1].

The /readyz handler is removed as it no longer has a consumer.

This supersedes commit f6ca9e056e47f444fb6dec147c9025321e31b5c6.

[1] https://github.com/kubevirt/kubevirtci/pull/1822#issuecomment-5436369483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated webhook server health monitoring to use a TCP readiness check on port 8443.
  * Removed the readiness endpoint from the health-check server; health checks now use the health endpoint only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->